### PR TITLE
leak_check attribute property

### DIFF
--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -28,6 +28,11 @@ __PACKAGE__->meta->add_attribute('traits' => (
     Class::MOP::_definition_context(),
 ));
 
+__PACKAGE__->meta->add_attribute('leak_check' => (
+    reader    => 'leak_check',
+    Class::MOP::_definition_context(),
+));
+
 # we need to have a ->does method in here to
 # more easily support traits, and the introspection
 # of those traits. We extend the does check to look
@@ -1383,6 +1388,35 @@ attribute is read.
 
 If this is true, the attribute's value will be stored as a weak
 reference.
+
+=item * leak_check => $bool || sub { ... }
+
+If this is true, a leak check will be run at object destruction.
+
+The leak check will weaken the instance's internal ref to the attribute. If the
+ref does not dissapear a warning will be issued. If a custom handler is
+provided in the form a coderef that will be run as well.
+
+B<Note>: This takes place in destruction, as such throwing an exception will
+not terminate execution.
+
+Example usage:
+
+    has bar => (
+        is => 'ro',
+        default => sub {[]},
+        leak_check => 1,
+    );
+
+    has baz => (
+        is => 'ro',
+        default => sub {[]},
+        leak_check => sub {
+            my $self = shift;
+            my ( $attr_name, $ref ) = @_;
+            ...
+        }
+    );
 
 =item * auto_deref => $bool
 

--- a/t/attributes/attribute_leak_check.t
+++ b/t/attributes/attribute_leak_check.t
@@ -1,0 +1,67 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+use Scalar::Util qw/weaken/;
+
+{
+    package Foo;
+    use Moose;
+    use Test::More;
+
+    our @NOT_CLEARED;
+
+    has bar => (
+        is => 'ro',
+        default => sub {[]},
+        leak_check => 1,
+    );
+
+    has baz => (
+        is => 'ro',
+        default => sub {[]},
+        leak_check => sub {
+            my $self = shift;
+            my ( $attr_name, $ref ) = @_;
+            # Get address of self for compare as self will be destroyed
+            push @NOT_CLEARED => [ "$self", $attr_name, $ref ];
+        }
+    );
+
+    has boo => (
+        is => 'ro',
+        default => sub {[]},
+        leak_check => 0,
+    );
+}
+
+my $one = Foo->new();
+my @hold = ( $one->bar, $one->baz, $one->boo );
+
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings => @_ };
+    my $self_string = "$one";
+    $one = undef;
+
+    is( @warnings, 2, "2 warning" );
+    like(
+        $warnings[@_],
+        qr/^External ref to attribute 'bar' detected on instance 'Foo=HASH/,
+        "Got warning $_"
+    ) for 0 .. 1;
+
+    is_deeply(
+        \@Foo::NOT_CLEARED,
+        [[ $self_string, 'baz', \$hold[1] ]],
+        "Custom handler ran."
+    );
+}
+
+# Ensure holds is not cleared early
+my $x = @hold;
+
+done_testing;


### PR DESCRIPTION
See here for my initial suggestion: http://article.gmane.org/gmane.comp.lang.perl.moose/2352

I am starting this pull request early, I know some work is necessary, but I would love feedback.

Issues:
- Probably does not work right when used on attributes in roles
- I do not have tests for attributes defined in base classes, though I added logic for them

I am not sure how to implement role support since there is the problem that the meta-class may not exist any longer during destruction.

This is probably not an issue in global destruction, only in instance destruction, as such it can probably use the meta-class and simply skip checks when the meta-class cannot be found? This requires testing. it is 2:00am here and this took longer than I expected.
