### PR TITLE
Make init_meta() calls in the order discussed on #moose-dev.

### DIFF
--- a/lib/Moose/Exporter.pm
+++ b/lib/Moose/Exporter.pm
@@ -420,7 +420,7 @@ sub _make_import_sub {
         warnings->import;
 
         my $did_init_meta;
-        for my $c ( grep { $_->can('init_meta') } $class, @{$exports_from} ) {
+        for my $c ( grep { $_->can('init_meta') } @{$exports_from}, $class ) {
 
             # init_meta can apply a role, which when loaded uses
             # Moose::Exporter, which in turn sets $CALLER, so we need

--- a/t/metaclasses/exporter_meta_lookup_order.t
+++ b/t/metaclasses/exporter_meta_lookup_order.t
@@ -1,0 +1,107 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::Fatal;
+use Test::More;
+
+my (@expected_call_order, @actual_call_order);
+
+{
+    package GreatGrandParent;
+    use Moose;
+    use Moose::Exporter;
+    use Test::More;
+
+    BEGIN {
+        push @expected_call_order, __PACKAGE__;
+
+        Moose::Exporter->setup_import_methods(
+            also        => 'Moose',
+            meta_lookup => sub { Class::MOP::class_of(__PACKAGE__) },
+        );
+    }
+
+    sub init_meta {
+        push @actual_call_order, __PACKAGE__;
+    }
+}
+
+{
+    package GrandParent;
+    use Moose;
+    use Moose::Exporter;
+    use Test::More;
+
+    BEGIN { GreatGrandParent->import() }
+
+    BEGIN {
+        push @expected_call_order, (
+            'GreatGrandParent',
+            __PACKAGE__,
+        );
+
+        Moose::Exporter->setup_import_methods(
+            also        => 'GreatGrandParent',
+            meta_lookup => sub { Class::MOP::class_of(__PACKAGE__) },
+        );
+    }
+
+    sub init_meta {
+        push @actual_call_order, __PACKAGE__;
+    }
+}
+
+{
+    package Parent;
+    use Moose;
+    use Moose::Exporter;
+    use Test::More;
+
+    BEGIN { GrandParent->import() }
+
+    BEGIN {
+        push @expected_call_order, (
+            'GreatGrandParent',
+            'GrandParent',
+            __PACKAGE__
+        );
+
+        Moose::Exporter->setup_import_methods(
+            also        => 'GrandParent',
+            meta_lookup => sub { Class::MOP::class_of(__PACKAGE__) },
+        );
+    }
+
+    sub init_meta {
+        push @actual_call_order, __PACKAGE__;
+    }
+}
+
+{
+    package Child;
+    use Moose;
+
+    BEGIN { Parent->import() }
+
+    sub init_meta {
+        # This init_meta() method is a guard against it being called.
+        # It shouldn't be called at all.
+        push @actual_call_order, __PACKAGE__;
+    }
+}
+
+Child->new();
+
+note("Expected call order: @expected_call_order");
+note("Actual   call order: @actual_call_order");
+
+is_deeply(
+    \@actual_call_order,
+    \@expected_call_order,
+    "init_meta()s called properly"
+);
+
+done_testing;
+


### PR DESCRIPTION
Moose::Exporter was calling init_meta() in the wrong order.  It should
initialize the least specific class (most ancestral one?) first,
followed by its descendents in order.
