### PR TITLE
allow testing a specific dist with MOOSE_TEST_MD

### DIFF
--- a/xt/author/test-my-dependents.t
+++ b/xt/author/test-my-dependents.t
@@ -130,7 +130,17 @@ my @dists = sort
             map  { $_->{fields}{distribution} }
             @{ $res->{hits}{hits} };
 
-unless ( $ENV{MOOSE_TEST_MD} eq 'all' ) {
+if ( $ENV{MOOSE_TEST_MD} eq 'all' ) {
+    # Do nothing; @dists is already the full list.
+    # Gosh, I hope there's no 'all' in @dist that someone wants to run in isolation
+} elsif ( any { $_ eq $ENV{MOOSE_TEST_MD} } @dists ) {
+    diag( "Based on MOOSE_TEST_MD value, testing only $ENV{MOOSE_TEST_MD}" );
+    @dists = $ENV{MOOSE_TEST_MD};
+    # Trying to figure out how to get here?
+        # Maybe you are setting MOOSE_TEST_MD=Foo-Bar-1.23 when
+        # you really want to do MOOSE_TEST_MD=Foo-Bar
+        # See also %name_fix above (you want the key from that hash, not the value).
+} else {
     diag(
         'Picking 200 random dependents to test. Set MOOSE_TEST_MD=all to test all dependents'
     );


### PR DESCRIPTION
MOOSE_TEST_MD=all
        tests all dists
    MOOSE_TEST_MD=Foo-Bar
        tests just the Foo-Bar dist
    MOOSE_TEST_MD=1
        (or = any other true value not mapping to a dist)
        tests 200 dists at random

```
When one of the 'all' or '200 rand' distributions fails, it is
handy to just edit the 1 or the 'all' to re-test just that one
distribution.
```
