### PR TITLE
Deleted extra comma in Moose::Manual::Types

### DIFF
--- a/lib/Moose/Manual/Types.pod
+++ b/lib/Moose/Manual/Types.pod
@@ -304,7 +304,7 @@ C<FileHandle>:
 
   has 'output' => (
       is  => 'rw',
-      isa => 'Object | FileHandle',
+      isa => 'Object | FileHandle'
   );
 
 Moose actually parses that string and recognizes that you are creating


### PR DESCRIPTION
Small misprint fixup in doc ;-)
