### PR TITLE
Defer string evals of inlined accessors and constructors until first run.

### DIFF
--- a/lib/Class/MOP/Method/Constructor.pm
+++ b/lib/Class/MOP/Method/Constructor.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Carp         'confess';
-use Scalar::Util 'blessed', 'weaken';
+use Scalar::Util 'blessed', 'weaken', 'refaddr', 'readonly';
 use Try::Tiny;
 
 use base 'Class::MOP::Method::Inlined';
@@ -100,15 +100,31 @@ sub _generate_constructor_method_inline {
 
     warn join("\n", @source) if $self->options->{debug};
 
-    my $code = try {
-        $self->_compile_code(\@source);
-    }
-    catch {
-        my $source = join("\n", @source);
-        confess "Could not eval the constructor :\n\n$source\n\nbecause :\n\n$_";
-    };
-
-    return $code;
+    my $new_coderef;
+    my $self_ref = \$self;
+    weaken($self);
+    my $orig_addr; $orig_addr = refaddr(my $sub_gen = bless sub {
+        my $self = ${$self_ref};
+        if (!defined($new_coderef)) {
+            $new_coderef = try {
+                $self->_compile_code(\@source);
+            }
+            catch {
+                my $source = join("\n", @source);
+                confess "Could not eval the constructor :\n\n$source\n\nbecause :\n\n$_";
+            };
+            # update the body member unless something else has stomped on it
+            my $body = $self->{'body'};
+            if ($orig_addr != refaddr($body)) {
+                # we seem to be outdated... paranoid future-proofing, I think..
+                goto $new_coderef = $body;
+            }
+            $self->{'body'} = $new_coderef;
+        };
+        return unless defined($_[0]);
+        goto $new_coderef;
+    },'RuNNeR');
+    return $sub_gen;
 }
 
 1;

--- a/t/immutable/inline_close_over.t
+++ b/t/immutable/inline_close_over.t
@@ -62,6 +62,10 @@ sub close_over_ok {
     my ($package, $method) = @_;
     my $visitor = Test::Visitor->new;
     my $code = $package->meta->find_method_by_name($method)->body;
+    if (ref($code) eq 'RuNNeR') {
+        $code->(undef);
+        $code = $package->meta->find_method_by_name($method)->body;
+    }
     $visitor->visit($code);
     if ($visitor->pass) {
         pass("${package}::${method} didn't close over anything complicated");


### PR DESCRIPTION
If the class has been made immutable, fixup the stash.
Reduced the -e 'use Moose' startup time by 17%, on my machine anyway.
Tested accesses of inlined accessors without a noticeable effect on
efficiency. It just moves the eval'ing to runtime, so if your program
runs every accessor and constructor before causing a visible side
effect, it won't be any faster. The entire point of the fake RuNNeR
package is to fake out the inline_close_over test. If another way is
found to do that, then the bless isn't necessary. For example, we
could add a way to "run all the things", forcing them to string eval,
and the test could run that. Also, such a thing might be useful to
preforking servers, who would want to still eval everything before
forking.
