### PR TITLE
Summarize native trait methods in the manual

### DIFF
--- a/lib/Moose/Manual/Delegation.pod
+++ b/lib/Moose/Manual/Delegation.pod
@@ -43,9 +43,12 @@ The simplest form is to simply specify a list of methods:
       handles => [qw( host path )],
   );
 
+Using a list tells Moose to create methods in your class that match
+the method names in the delegated class.
+
 With this definition, we can call C<< $website->host >> and it "just
 works". Under the hood, Moose will call C<< $website->uri->host >> for
-you. Note that C<$website> is not automatically passed to the C<host>
+you. Note that C<$website> is I<not> automatically passed to the C<host>
 method; the invocant is C<< $website->uri >>.
 
 We can also define a mapping as a hash reference. This allows you to
@@ -64,8 +67,13 @@ rename methods as part of the mapping:
       },
   );
 
+Using a hash tells Moose to create method names (specified on the 
+left) which invoke the delegated class methods (specified on the
+right).
+
 In this example, we've created a C<< $website->hostname >> method,
-rather than using C<URI.pm>'s name, C<host>.
+rather than simply using C<URI.pm>'s name, C<host> in the Website
+class.
 
 These two mapping forms are the ones you will use most often. The
 remaining methods are a bit more complex.
@@ -91,11 +99,12 @@ You can use a role name as the value of C<handles>:
   );
 
 Moose will introspect the role to determine what methods it provides
-and create a mapping for each of those methods.
+and create a name-for-name mapping for each of those methods.
 
-Finally, you can also provide a sub reference to I<generate> a
-mapping. You probably won't need this version often (if ever). See the
-L<Moose> docs for more details on exactly how this works.
+Finally, you can provide a sub reference to I<generate> a mapping 
+that behaves like the hash example above. You probably won't need 
+this version often (if ever). See the L<Moose> docs for more details 
+on exactly how this works.
 
 =head1 NATIVE DELEGATION
 


### PR DESCRIPTION
Summarize available methods for each native trait. Also clarify the behavior when mapping delegated methods into a class for arrayrefs and hashrefs.
