### PR TITLE
Fix Moose tests after perl rt#118561

### DIFF
--- a/t/cmop/instance_metaclass_incompat.t
+++ b/t/cmop/instance_metaclass_incompat.t
@@ -20,6 +20,7 @@ use metaclass;
 $@ = undef;
 eval {
     package Foo;
+    BEGIN { $INC{'Foo.pm'} = __FILE__ }
     metaclass->import('instance_metaclass' => 'Foo::Meta::Instance');
 };
 ok(!$@, '... Foo.meta => Foo::Meta is compatible') || diag $@;
@@ -27,6 +28,7 @@ ok(!$@, '... Foo.meta => Foo::Meta is compatible') || diag $@;
 $@ = undef;
 eval {
     package Bar;
+    BEGIN { $INC{'Bar.pm'} = __FILE__ }
     metaclass->import('instance_metaclass' => 'Bar::Meta::Instance');
 };
 ok(!$@, '... Bar.meta => Bar::Meta is compatible') || diag $@;


### PR DESCRIPTION
Newer versions of base.pm will be more strict about when to ignore a failure finding the module file.  It will only consider the module already loaded if there are any variables in the stash.  Previously, it would also consider modules with existing submodules as loaded.

This fixes it by manually setting @ISA, avoiding base's heuristic entirely.  If a different style is preferred, let me know.
