### PR TITLE
Fix Moose::Util{s,}:: typos

### DIFF
--- a/lib/Moose/Cookbook/Snack/Keywords.pod
+++ b/lib/Moose/Cookbook/Snack/Keywords.pod
@@ -165,7 +165,7 @@ you must be careful not to remove C<meta> when doing so:
 
 =item L<Moose::Role>
 
-=item L<Moose::Utils::TypeConstraints>
+=item L<Moose::Util::TypeConstraints>
 
 =item L<Sub::Exporter>
 

--- a/lib/Moose/Cookbook/Snack/Types.pod
+++ b/lib/Moose/Cookbook/Snack/Types.pod
@@ -60,7 +60,7 @@ to check a value directly.
 
 =item L<Moose::Cookbook::Basics::Point_AttributesAndSubclassing>
 
-=item L<Moose::Utils::TypeConstraints>
+=item L<Moose::Util::TypeConstraints>
 
 =item L<Moose::Meta::Attribute>
 


### PR DESCRIPTION
Minor documentation typos in references to Moose::Util::TypeConstraints in two places. s/Utils/Util/.
