### PR TITLE
version number not getting incremented

### DIFF
--- a/lib/Moose/Cookbook/Legacy/Debugging_BaseClassReplacement.pod
+++ b/lib/Moose/Cookbook/Legacy/Debugging_BaseClassReplacement.pod
@@ -12,7 +12,7 @@ Moose::Cookbook::Extending::Recipe3 - Providing an alternate base object class
 
 =head1 VERSION
 
-version 2.0402
+version 2.0405
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
This makes cpan-outdated confused:

cpan-outdated --verbose
Moose::Cookbook::Legacy::Debugging_BaseClassReplacement 2.0802  2.1005  E/ET/ETHER/Moose-2.1005.tar.gz
