### PR TITLE
Fixed incorrect Catalyst version number for bin/moose-outdated script

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -242,7 +242,7 @@ Dist::Zilla::Plugin::Conflicts = == 0.11
 
 [Conflicts]
 -script = bin/moose-outdated
-Catalyst                       = 5.9049999
+Catalyst                       = 5.90049999
 Config::MVP                    = 2.200004
 Devel::REPL                    = 1.003020
 Dist::Zilla::Plugin::Git       = 2.016


### PR DESCRIPTION
The specified Catalyst version was missing a zero.

It was set to 5.9049999, but the latest Catalyst is 5.90053, so installing Moose generated this warning:

```
***
    Conflicts detected for Moose:
      Catalyst is version 5.90053, but must be greater than version 5.9049999
***
```
