### PR TITLE
Some mistake in documentation

### DIFF
--- a/lib/Moose/Util/TypeConstraints.pm
+++ b/lib/Moose/Util/TypeConstraints.pm
@@ -1,4 +1,3 @@
-
 package Moose::Util::TypeConstraints;
 
 use Carp ();
@@ -787,7 +786,7 @@ __END__
 
   enum 'RGBColors', [qw(red green blue)];
 
-  union 'StringOrArray', [qw( String Array )];
+  union 'StringOrArray', [qw( String ArrayRef )];
 
   no Moose::Util::TypeConstraints;
 


### PR DESCRIPTION
In perldoc Moose::Util::TypeConstraints, union 'StringOrArray', [qw( String Array )];  I think it should be Str & ArrayRef instead.
