### PR TITLE
Few improvements in doc: changed entities like C<Some::Class> to links like L<Some::Class>

### DIFF
--- a/lib/Class/MOP/Attribute.pm
+++ b/lib/Class/MOP/Attribute.pm
@@ -947,7 +947,7 @@ and by metaclass instances.
 
 =item B<< $attr->associated_class >>
 
-This returns the C<Class::MOP::Class> with which this attribute is
+This returns the L<Class::MOP::Class> with which this attribute is
 associated, if any.
 
 =item B<< $attr->attach_to_class($metaclass) >>
@@ -1038,5 +1038,3 @@ metaclass.
 =back
 
 =cut
-
-

--- a/lib/Class/MOP/Method/Constructor.pm
+++ b/lib/Class/MOP/Method/Constructor.pm
@@ -143,7 +143,7 @@ __END__
 
 =head1 DESCRIPTION
 
-This is a subclass of C<Class::MOP::Method> which generates
+This is a subclass of L<Class::MOP::Method> which generates
 constructor methods.
 
 =head1 METHODS
@@ -188,4 +188,3 @@ This returns the L<Class::MOP::Class> object for the method.
 =back
 
 =cut
-

--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -878,12 +878,12 @@ This adds an C<augment> method modifier to the package.
 
 =item B<< $metaclass->calculate_all_roles >>
 
-This will return a unique array of C<Moose::Meta::Role> instances
+This will return a unique array of L<Moose::Meta::Role> instances
 which are attached to this class.
 
 =item B<< $metaclass->calculate_all_roles_with_inheritance >>
 
-This will return a unique array of C<Moose::Meta::Role> instances
+This will return a unique array of L<Moose::Meta::Role> instances
 which are attached to this class, and each of this class's ancestors.
 
 =item B<< $metaclass->add_role($role) >>
@@ -935,4 +935,3 @@ read-write, so you can use them to change the class name.
 See L<Moose/BUGS> for details on reporting bugs.
 
 =cut
-


### PR DESCRIPTION
Few improvements in doc: changed entities like CSome::Class to links like LSome::Class
Some few pieces in Moose's doc has not link. I think it's very strange since it is not convenient
Sorry if pull request in main branch - please pull in your preferable branch if it should be needed
