### PR TITLE
small fix of doc Moose::Exporter

### DIFF
--- a/lib/Moose/Exporter.pm
+++ b/lib/Moose/Exporter.pm
@@ -919,7 +919,7 @@ Accordingly, this function is expected to return a metaclass.
 =back
 
 You can also provide parameters for C<Moose::Util::MetaRole::apply_metaroles>
-and C<Moose::Util::MetaRole::base_class_roles>. Specifically, valid parameters
+and C<Moose::Util::MetaRole::apply_base_class_roles>. Specifically, valid parameters
 are "class_metaroles", "role_metaroles", and "base_class_roles".
 
 =item B<< Moose::Exporter->build_import_methods(...) >>


### PR DESCRIPTION
There is apply_base_class_roles method not base_class_roles
