### PR TITLE
IMPORTANT! Applied patch from author of Module::Runtime

### DIFF
--- a/lib/Moose/Util.pm
+++ b/lib/Moose/Util.pm
@@ -135,7 +135,7 @@ sub _apply_all_roles {
             $meta = $role->[0];
         }
         else {
-            use_module($role->[0], $role->[1] ? $role->[1]{-version} : ());
+            &use_module($role->[0], $role->[1] ? $role->[1]{-version} : ());
             $meta = find_meta( $role->[0] );
         }
 
@@ -337,7 +337,7 @@ sub meta_class_alias {
 
 sub _load_user_class {
     my ($class, $opts) = @_;
-    use_package_optimistically(
+    &use_package_optimistically(
         $class,
         $opts ? $opts->{-version} : ()
     );


### PR DESCRIPTION
I didn't test it
But now Moose's tests are failed affected by Module::Runtime 0.014 (today version)
Example of errors:

```
>#     Error:  Invalid version format (version required) at
>/usr/local/lib/perl5/site_perl/5.16.2/Module/Runtime.pm line 386.
```

From author of Module::Runtime:

Some of Moose's code that uses M:R is passing undef for the version
parameter of use_module() or use_package_optimistically(), when it should
pass no version parameter.  The new version of M:R handles this correctly,
treating it as a version number that turns out to be invalid, whereas the
old version mistook undef for a lack of parameter.  The bug is in Moose.
