### PR TITLE
A bunch of memory cycles based around meta and CMOP

### DIFF
--- a/xt/author/memory_leaks.t
+++ b/xt/author/memory_leaks.t
@@ -172,12 +172,9 @@ no_leaks_ok(
 }
 
 {
-    my $planet = Earth->new;
-    memory_cycle_ok($planet->meta, 'meta (handles) is cycle-free');
-}
-
-{
-    memory_cycle_ok(Earth->meta, 'meta (class) is cycle-free');
+    local $TODO = 'meta cycles exist at the moment';
+    memory_cycle_ok(Earth->new->meta, 'meta (handles) is cycle-free');
+    memory_cycle_ok(Earth->meta,      'meta (class) is cycle-free');
 }
 
 {
@@ -224,6 +221,7 @@ no_leaks_ok(
         }
     ));
 
+    local $TODO = 'CMOP cycles exist at the moment';
     memory_cycle_ok($Point3D,       'Point3D is cycle-free');
     memory_cycle_ok($Point,         'Point is cycle-free');
     memory_cycle_ok($Point3D->meta, 'Point3D meta is cycle-free');


### PR DESCRIPTION
Found a bunch of these memory cycles in relation to Moose::Meta and Class::MOP objects.  Provided some examples in the form of additional tests to memory_leaks.t
