### PR TITLE
Mention the newly added Moose::Util::is_role() in Moose::Role

### DIFF
--- a/lib/Moose/Role.pm
+++ b/lib/Moose/Role.pm
@@ -263,6 +263,10 @@ this, your class's C<meta> object will have the specified traits
 applied to it. See L<Moose/Metaclass and Trait Name Resolution> for more
 details.
 
+All role metaclasses (note, not the role class itself) extend
+L<Moose::Meta::Role>.  You can test if a class is a role class or not using
+L<Moose::Util/is_role>.
+
 =head1 APPLYING ROLES
 
 In addition to being applied to a class using the 'with' syntax (see


### PR DESCRIPTION
Moose::Role is a likely spot to look for such a function.  Noting the
metaclass involved may be useful for folks rolling their own is_role()
checks.
