### PR TITLE
Fixed RT-94731

### DIFF
--- a/lib/Moose/Exception/CannotLocatePackageInINC.pm
+++ b/lib/Moose/Exception/CannotLocatePackageInINC.pm
@@ -2,7 +2,7 @@ package Moose::Exception::CannotLocatePackageInINC;
 
 use Moose;
 extends 'Moose::Exception';
-with 'Moose::Exception::Role::TypeConstraint', 'Moose::Exception::Role::ParamsHash';
+with 'Moose::Exception::Role::ParamsHash';
 
 has 'INC' => (
     is       => 'ro',
@@ -20,6 +20,12 @@ has 'metaclass_name' => (
     is       => 'ro',
     isa      => 'Str',
     required => 1
+);
+
+has 'type' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
 );
 
 sub _build_message {

--- a/t/exceptions/util.t
+++ b/t/exceptions/util.t
@@ -151,16 +151,18 @@ use Moose::Util qw/apply_all_roles add_method_modifier/;
 }
 
 {
-    use Moose::Util;
-    use Moose::Util::TypeConstraints;
-
     my $exception = exception {
-        Moose::Util::resolve_metaclass_alias(find_type_constraint('Int'), 'Xyz');
+        package My::Class;
+        use Moose;
+        has 'attr' => (
+            is     => 'ro',
+            traits => [qw( Xyz )],
+        );
     };
 
     like(
         $exception,
-        qr/^Can't locate Moose::Meta::Int::Custom::Xyz or Xyz in \@INC \(\@INC contains:/,
+        qr/^Can't locate Moose::Meta::Attribute::Custom::Trait::Xyz or Xyz in \@INC \(\@INC contains:/,
         "Cannot locate 'Xyz'");
 
     isa_ok(
@@ -169,13 +171,13 @@ use Moose::Util qw/apply_all_roles add_method_modifier/;
         "Cannot locate 'Xyz'");
 
     is(
-	$exception->type_name,
-	"Int",
+	$exception->type,
+	"Attribute",
         "Cannot locate 'Xyz'");
 
     is(
 	$exception->possible_packages,
-	'Moose::Meta::Int::Custom::Xyz or Xyz',
+	'Moose::Meta::Attribute::Custom::Trait::Xyz or Xyz',
         "Cannot locate 'Xyz'");
 
     is(


### PR DESCRIPTION
CannotLocatePackageInINC exception has type which
isa 'Moose::Meta::TypeConstraint', but it should
be isa => 'Str'.

Also, test case for this exception was calling
resolve_metaclass_alias method directly, using trait
for testing this exception is a better idea, because it
explains this exception better.
