### PR TITLE
Add Version Badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CPAN version](https://badge.fury.io/pl/Moose.svg)](http://badge.fury.io/pl/Moose)
 [![Build Status](https://travis-ci.org/moose/Moose.png?branch=master,stable/2.08)](https://travis-ci.org/moose/Moose)
 
 Moose


### PR DESCRIPTION
As we've discussed with @karenetheridge, we are making an effort to standardize the way developers discover CPAN distributions from Github repos.  We've had quite a bit of [success and support](http://badge.fury.io/projects) from package authors for other languages, and wanted to contribute to the Perl and CPAN community.

It looks a little different than the Travis CI old PNG badge until they switch to their [new design](http://blog.travis-ci.com/2014-03-20-build-status-badges-support-svg/).
