### PR TITLE
Use travis helpers for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,26 @@
 language: perl
 perl:
     #- dev
-    - "5.19"
+    - "blead"
     #- stable
+    - "5.20"
     - "5.18"
     - "5.16"
     - "5.14"
     - "5.12"
     - "5.10"
+    - "5.8"
+before_install:
+  - git clone git://github.com/haarg/perl-travis-helper
+  - source perl-travis-helper/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR
 install:
-    - cpanm -q --notest Moose || (cat /home/travis/.cpanm/build.log; false)
-    - cpanm -q --notest Dist::Zilla || (cat /home/travis/.cpanm/build.log; false)
-    - dzil authordeps --missing | grep -v '^inc::' | cpanm -q --notest || (cat /home/travis/.cpanm/build.log; false)
-    - dzil listdeps --author --missing | cpanm -q --notest || (cat /home/travis/.cpanm/build.log; false)
+  - cpan-install ExtUtils::MakeMaker~6.68 --deps
+  - cpan-install --coverage
 script:
-    - dzil test --all
+  - perl Makefile.PL
+  - make
+  - RELEASE_TESTING=1 prove -b -r -s -j$((SYSTEM_CORES + 1)) $(test-dirs)

--- a/dist.ini
+++ b/dist.ini
@@ -225,7 +225,7 @@ File::Spec = 0
 ;Config = 0     ; not actually in 02packages.details.txt!!!
 
 [Prereqs::AuthorDeps]
-relation = recommends
+relation = suggests
 exclude = inc::CheckDelta
 exclude = inc::Clean
 exclude = inc::ExtractInlineTests


### PR DESCRIPTION
This allows testing on arbitrary versions of perl, including blead.  It
also splits the dist creation with Dist::Zilla from the rest of the building
and testing.  This allows testing on perl 5.8, even though the dzil
plugins don't all work there.
