### PR TITLE
Implemented Test::Moose lacks_attribute_ok

### DIFF
--- a/lib/Test/Moose.pm
+++ b/lib/Test/Moose.pm
@@ -13,6 +13,7 @@ my @exports = qw[
     meta_ok
     does_ok
     has_attribute_ok
+    lacks_attribute_ok
     with_immutable
 ];
 
@@ -65,6 +66,21 @@ sub has_attribute_ok ($$;$) {
     }
     else {
         return $Test->ok(0, $message);
+    }
+}
+
+sub lacks_attribute_ok ($$;$) {
+    my ($class_or_obj, $attr_name, $message) = @_;
+
+    $message ||= "The object does not have an attribute named $attr_name";
+
+    my $meta = find_meta($class_or_obj);
+
+    if ($meta->find_attribute_by_name($attr_name)) {
+        return $Test->ok(0, $message);
+    }
+    else {
+        return $Test->ok(1, $message)
     }
 }
 
@@ -123,6 +139,11 @@ does for the C<isa> method.
 
 Tests if a class or object has a certain attribute, similar to what C<can_ok>
 does for the methods.
+
+=item B<lacks_attribute_ok($class_or_object, $attr_name, ?$message)>
+
+Tests if a class or object lacks a certain attribute, similiar to a what
+a negated version of C<can_ok> does for the methods.
 
 =item B<with_immutable { CODE } @class_names>
 

--- a/t/test_moose/test_moose_lacks_attribute_ok.t
+++ b/t/test_moose/test_moose_lacks_attribute_ok.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+
+use Test::Builder::Tester;
+use Test::More;
+
+use Test::Moose;
+
+{
+    package Foo;
+    use Moose;
+
+    has 'foo', is => 'bare';
+}
+
+{
+    package Bar;
+    use Moose;
+
+    extends 'Foo';
+
+    has 'bar', is => 'bare';
+}
+
+
+test_out('ok 1 - ... lacks_attribute_ok(Foo, bar) passes');
+lacks_attribute_ok('Foo', 'bar', '... lacks_attribute_ok(Foo, bar) passes');
+
+test_out ('not ok 2 - ... lacks_attribute_ok(Foo, foo) fails');
+test_fail (+1);
+lacks_attribute_ok('Foo', 'foo', '... lacks_attribute_ok(Foo, foo) fails');
+
+test_out('not ok 3 - ... lacks_attribute_ok(Bar, foo) fails');
+test_fail (+1);
+lacks_attribute_ok('Bar', 'foo', '... lacks_attribute_ok(Bar, foo) fails');
+
+test_out('not ok 4 - ... lacks_attribute_ok(Bar, bar) fails');
+test_fail (+1);
+lacks_attribute_ok('Bar', 'bar', '... lacks_attribute_ok(Bar, bar) fails');
+
+test_out('ok 5 - ... lacks_attribute_ok(Bar, baz) passes');
+lacks_attribute_ok('Bar', 'baz', '... lacks_attribute_ok(Bar, baz) passes');
+
+test_test ('lacks_attribute_ok');
+
+done_testing;


### PR DESCRIPTION
Introduces a new method into Test::Moose, lacks_attribute_ok

lacks_attribute_ok is simply a negated version of has_attribute_ok.  I find myself needing this functionality especially when I am constructing objects with arguments that are not actually attributes (such as using a class method that will encrypt a password before storing it in the encrypted_password attribute, or any time BUILDARGS magic is happening).

POD has been added in lib/Test/Moose.pm

A test has been created in t/test_moose/test_moose_lacks_attribute_ok.t which implements tests for the below use cases
    Object lacks an attribute that it actually lacks            (Pass)
    Object lacks an attribute that it actually has              (Fail)
    Extended Object lacks an attribute that the base object has (Fail)
    Extended Object lacks an attribute that it actually has     (Fail)
    Extended Object lacks an attribute that it actually lacks   (Pass)

I'm happy to make any changes you feel are needed, or discuss the efficacy and utility of this new method.  Thanks for considering it!
