### PR TITLE
Export confess and blessed by name rather than by subref

### DIFF
--- a/lib/Moose.pm
+++ b/lib/Moose.pm
@@ -135,8 +135,8 @@ Moose::Exporter->setup_import_methods(
     ],
     as_is => [
         qw( super inner ),
-        \&Carp::confess,
-        \&Scalar::Util::blessed,
+        'Carp::confess',
+        'Scalar::Util::blessed',
     ],
 );
 

--- a/lib/Moose/Exporter.pm
+++ b/lib/Moose/Exporter.pm
@@ -294,6 +294,16 @@ sub _make_sub_exporter_params {
                     $is_reexport->{$coderef_name} = 1;
                 }
             }
+            elsif ( $name =~ /^(.*)::([^:]+)$/ ) {
+                $sub = $class->_sub_from_package( "$1", "$2" )
+                    or next;
+
+                $coderef_name = "$2";
+
+                if ( $1 ne $package ) {
+                    $is_reexport->{$coderef_name} = 1;
+                }
+            }
             else {
                 $sub = $class->_sub_from_package( $package, $name )
                     or next;
@@ -796,7 +806,7 @@ __END__
 
   Moose::Exporter->setup_import_methods(
       with_meta => [ 'has_rw', 'sugar2' ],
-      as_is     => [ 'sugar3', \&Some::Random::thing ],
+      as_is     => [ 'sugar3', \&Some::Random::thing, 'Other::Random::thing' ],
       also      => 'Moose',
   );
 

--- a/lib/Moose/Role.pm
+++ b/lib/Moose/Role.pm
@@ -96,8 +96,8 @@ Moose::Exporter->setup_import_methods(
     ],
     as_is => [
         qw( extends super inner augment ),
-        \&Carp::confess,
-        \&Scalar::Util::blessed,
+        'Carp::confess',
+        'Scalar::Util::blessed',
     ],
 );
 

--- a/t/metaclasses/moose_exporter.t
+++ b/t/metaclasses/moose_exporter.t
@@ -344,7 +344,7 @@ use Test::Requires 'Test::Output';  # skip all if not installed
         also        => ['Moose'],
         with_meta   => [ 'with_meta1', 'with_meta2' ],
         with_caller => [ 'with_caller1', 'with_caller2' ],
-        as_is       => ['as_is1', \&Foreign::Class::as_is2 ],
+        as_is       => ['as_is1', \&Foreign::Class::as_is2, 'Foreign::Class::as_is3'],
     );
 
     sub with_caller1 {
@@ -358,6 +358,7 @@ use Test::Requires 'Test::Output';  # skip all if not installed
     sub as_is1 {2}
 
     sub Foreign::Class::as_is2 { return 'as_is2' }
+    sub Foreign::Class::as_is3 { return 'as_is3' }
 
     sub with_meta1 {
         return @_;
@@ -376,7 +377,7 @@ use Test::Requires 'Test::Output';  # skip all if not installed
 
 {
     can_ok( 'UseAllOptions', $_ )
-        for qw( with_meta1 with_meta2 with_caller1 with_caller2 as_is1 as_is2 );
+        for qw( with_meta1 with_meta2 with_caller1 with_caller2 as_is1 as_is2 as_is3 );
 
     {
         my ( $caller, $arg1 ) = UseAllOptions::with_caller1(42);
@@ -410,7 +411,7 @@ use Test::Requires 'Test::Output';  # skip all if not installed
 
 {
     ok( ! UseAllOptions->can($_), "UseAllOptions::$_ has been unimported" )
-        for qw( with_meta1 with_meta2 with_caller1 with_caller2 as_is1 as_is2 );
+        for qw( with_meta1 with_meta2 with_caller1 with_caller2 as_is1 as_is2 as_is3 );
 }
 
 {


### PR DESCRIPTION
When exporting by subref, we have to look up the name of the sub.  If
someone has monkey patched that sub, it will likely be anonymous and not
have a name.  Contextual::Return currently does this, breaking parts of
Moose internally if it is loaded first (RT#88669).

When we already have the name of the sub, we shouldn't need to look it
up.  Add support to Moose::Exporter for exporting subs by their fully
qualified name, and use that to export confess and blessed.
