### PR TITLE
list all runtime and configure prerequisites as authordeps

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -197,33 +197,60 @@ skip = ^Moose::Meta::TypeConstraint::Union$
 [CheckChangesHasContent]
 ;[CheckPrereqsIndexed]
 
+; all runtime deps must be author deps
 [Prereqs]
-parent                      = 0.223
-Carp                        = 1.22
-Class::Load                 = 0.09
-Class::Load::XS             = 0.01
-Data::OptList               = 0.107
-Devel::GlobalDestruction    = 0
-Eval::Closure               = 0.04
-List::MoreUtils             = 0.28
-Module::Runtime             = 0.014
-Module::Runtime::Conflicts  = 0
-MRO::Compat                 = 0.05
-Package::DeprecationManager = 0.11
-Package::Stash              = 0.32
-Package::Stash::XS          = 0.24
-Params::Util                = 1.00
-Scalar::Util                = 1.19
-Sub::Exporter               = 0.980
-Sub::Name                   = 0.05
-Task::Weaken                = 0
-Try::Tiny                   = 0.02
-perl                        = 5.8.3
-Devel::StackTrace           = 1.33
-strict                      = 1.03
-warnings                    = 1.03
-Devel::OverloadInfo         = 0.002
-List::Util                  = 1.33
+           parent                      = 0.223
+;authordep parent                      = 0.223
+           Carp                        = 1.22
+;authordep Carp                        = 1.22
+           Class::Load                 = 0.09
+;authordep Class::Load                 = 0.09
+           Class::Load::XS             = 0.01
+;authordep Class::Load::XS             = 0.01
+           Data::OptList               = 0.107
+;authordep Data::OptList               = 0.107
+           Devel::GlobalDestruction    = 0
+;authordep Devel::GlobalDestruction    = 0
+           Eval::Closure               = 0.04
+;authordep Eval::Closure               = 0.04
+           List::MoreUtils             = 0.28
+;authordep List::MoreUtils             = 0.28
+           Module::Runtime             = 0.014
+;authordep Module::Runtime             = 0.014
+           Module::Runtime::Conflicts  = 0
+;authordep Module::Runtime::Conflicts  = 0
+           MRO::Compat                 = 0.05
+;authordep MRO::Compat                 = 0.05
+           Package::DeprecationManager = 0.11
+;authordep Package::DeprecationManager = 0.11
+           Package::Stash              = 0.32
+;authordep Package::Stash              = 0.32
+           Package::Stash::XS          = 0.24
+;authordep Package::Stash::XS          = 0.24
+           Params::Util                = 1.00
+;authordep Params::Util                = 1.00
+           Scalar::Util                = 1.19
+;authordep Scalar::Util                = 1.19
+           Sub::Exporter               = 0.980
+;authordep Sub::Exporter               = 0.980
+           Sub::Name                   = 0.05
+;authordep Sub::Name                   = 0.05
+           Task::Weaken                = 0
+;authordep Task::Weaken                = 0
+           Try::Tiny                   = 0.02
+;authordep Try::Tiny                   = 0.02
+           perl                        = 5.8.3
+;authordep perl                        = 5.8.3
+           Devel::StackTrace           = 1.33
+;authordep Devel::StackTrace           = 1.33
+           strict                      = 1.03
+;authordep strict                      = 1.03
+           warnings                    = 1.03
+;authordep warnings                    = 1.03
+           Devel::OverloadInfo         = 0.002
+;authordep Devel::OverloadInfo         = 0.002
+           List::Util                  = 1.33
+;authordep List::Util                  = 1.33
 
 [Prereqs / TestRequires]
 Test::CleanNamespaces = 0.13
@@ -232,9 +259,12 @@ Test::More            = 0.88
 Test::Requires        = 0.05
 Test::Warnings        = 0.016
 
+; all configure deps must be author deps
 [Prereqs / ConfigureRequires]
-ExtUtils::CBuilder = 0.27
-File::Spec = 0
+           ExtUtils::CBuilder = 0.27
+;authordep ExtUtils::CBuilder = 0.27
+           File::Spec = 0
+;authordep File::Spec = 0
 ;Config = 0     ; not actually in 02packages.details.txt!!!
 
 [Prereqs::AuthorDeps]


### PR DESCRIPTION
Part of Moose's documentation is built by introspecting the classes.
This means we need to be able to build and run Moose itself for a dzil
build to succeed.  This hasn't been a problem until now, because we
already have Moose installed as a prerequisite of Dist::Zilla.  But when
we add prereqs, the installed prereqs aren't enough.
