### PR TITLE
Work around weirdness with MX::MarkAsMethods and overloading roles

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,20 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  - The core overloading support interacted badly with
+    MooseX::MarkAsMethods. If you used MooseX::MarkAsMethods in a role that
+    provided overloading, then that overloading would not be properly applied
+    to consuming classes, leading to very weird errors of the form:
+
+        Can't resolve method "???" overloading """" in package "Class2" ...
+
+    Note that the problems that MooseX::MarkAsMethods fixes are no longer
+    present if you are using Moose 2.1400+ and namespace::autoclean 0.16+. We
+    encourage you to upgrade both of these modules and remove
+    MooseX::MarkAsMethods from your code base.
+
 2.1400   2014-10-31
 
   [BUG FIXES]

--- a/dist.ini
+++ b/dist.ini
@@ -295,6 +295,7 @@ IO::File                     = 0
 IO::String                   = 0
 Locale::US                   = 0
 Module::Refresh              = 0
+MooseX::MarkAsMethods        = 0
 PadWalker                    = 0
 Params::Coerce               = 0
 Regexp::Common               = 0

--- a/lib/Moose/Meta/Role/Application.pm
+++ b/lib/Moose/Meta/Role/Application.pm
@@ -54,9 +54,9 @@ sub apply {
     $self->check_required_methods(@_);
     $self->check_required_attributes(@_);
 
+    $self->apply_overloading(@_);
     $self->apply_attributes(@_);
     $self->apply_methods(@_);
-    $self->apply_overloading(@_);
 
     $self->apply_override_method_modifiers(@_);
 

--- a/t/bugs/mark_as_methods_overloading_breakage.t
+++ b/t/bugs/mark_as_methods_overloading_breakage.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use Moose ();
+# Needed to load MarkAsMethods if we're running from a git checkout
+BEGIN { $Moose::VERSION ||= 42 }
+
+use Test::More;
+use Test::Exception;
+use Test::Requires {
+    'MooseX::MarkAsMethods' => 0,
+};
+
+{
+    package Role2;
+    use Moose::Role;
+    use MooseX::MarkAsMethods;
+    use overload q{""} => '_stringify';
+    sub _stringify {ref $_[0]}
+}
+
+{
+    package Class2;
+    use Moose;
+    with 'Role2';
+}
+
+lives_ok {
+    my $class2 = Class2->new;
+    is(
+        "$class2",
+        'Class2',
+        'Class2 got stringification overloading from Role2'
+    );
+}
+'No error creating a Class2 object';
+
+done_testing;


### PR DESCRIPTION
Marking overload subs like ("" as methods caused them to be copied from the
class to the role. This made the class _look_ like it implemented overloading
for the op, but overloading wasn't actually enabled, causing weird errors.
