### PR TITLE
fix a test that was trying to load Test::Exception instead of Test::Fata...

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Also see Moose::Manual::Delta for more details of, and workarounds
 for, noteworthy changes.
 
 {{$NEXT}}
+  - Fix a test that was trying to load Test::Exception instead of Test::Fatal.
+    (Michael Schout)
 
 2.1401   2014-11-03
 

--- a/t/bugs/mark_as_methods_overloading_breakage.t
+++ b/t/bugs/mark_as_methods_overloading_breakage.t
@@ -6,7 +6,7 @@ use Moose ();
 BEGIN { $Moose::VERSION ||= 42 }
 
 use Test::More;
-use Test::Exception;
+use Test::Fatal;
 use Test::Requires {
     'MooseX::MarkAsMethods' => 0,
 };


### PR DESCRIPTION
This test was trying to load Test::Exception instead of Test::Fatal.  Test::Exception is not in the PREREQ_PM list, so this test fails if Test::Exception is not already installed.  Looking back at the history, it seems that Test::Fatal is what was intended here.
