### PR TITLE
fix a test that was trying to load Test::Exception instead of Test::Fata...

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Also see Moose::Manual::Delta for more details of, and workarounds
 for, noteworthy changes.
 
 {{$NEXT}}
+  - Fix a test that was trying to load Test::Exception instead of Test::Fatal.
+    (Michael Schout)
 
 2.1401   2014-11-03
 

--- a/t/bugs/mark_as_methods_overloading_breakage.t
+++ b/t/bugs/mark_as_methods_overloading_breakage.t
@@ -6,7 +6,7 @@ use Moose ();
 BEGIN { $Moose::VERSION ||= 42 }
 
 use Test::More;
-use Test::Exception;
+use Test::Fatal;
 use Test::Requires {
     'MooseX::MarkAsMethods' => 0,
 };
@@ -25,14 +25,13 @@ use Test::Requires {
     with 'Role2';
 }
 
-lives_ok {
+ok(! exception {
     my $class2 = Class2->new;
     is(
         "$class2",
         'Class2',
         'Class2 got stringification overloading from Role2'
     );
-}
-'No error creating a Class2 object';
+}, 'No error creating a Class2 object');
 
 done_testing;


### PR DESCRIPTION
A test using Test::Exception (which is not in requirements list) snuck into latest release.  Ported over to Test::Fatal
