### PR TITLE
Don't add command line option if compiler is cl

### DIFF
--- a/inc/MMHelper.pm
+++ b/inc/MMHelper.pm
@@ -9,8 +9,9 @@ sub ccflags_dyn {
     my $is_dev = shift;
 
     my $ccflags = q<( $Config::Config{ccflags} || '' ) . ' -I.'>;
-    $ccflags .= q< . ' -Wall -Wdeclaration-after-statement'>
-        if $is_dev;
+    if ($is_dev and ($Config{cc} !~ /^cl\b/i)) {
+        $ccflags .= q< . ' -Wall -Wdeclaration-after-statement'>;
+    }
 
     return $ccflags;
 }


### PR DESCRIPTION
`cl` does not understand `-Wdeclaration-after-statement`. I am trying to figure out if there is a corresponding warning option for `cl`, but, in the mean time, not adding this command line option when the compiler is `cl` will allow users to build Moose from a `git` checkout directory using `cl` on Windows.

Thank you.

-- Sinan
