### PR TITLE
Remove superfluous entries from develop.suggests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,6 +12,7 @@ Jay Hannah <jay@jays.net> jhannah <jay@jays.net>
 John Napiorkowski <jjnapiork@cpan.org> John Napiorkowski <johnn@John-Napiorkowski-MacBook-Pro.local>
 John Napiorkowski <jjnapiork@cpan.org> John Napiorkowski <johnn@new-host.home>
 Justin Hunter <justin.d.hunter@gmail.com> arcanez <justin.d.hunter@gmail.com>
+Kent Fredric <kentnl@cpan.org> Kent Fredric <kentfredric@gmail.com>
 Karen Etheridge <ether@cpan.org> Karen Etheridge <karen@etheridge.ca>
 Karen Etheridge <ether@cpan.org> Karen Etheridge <github@froods.org>
 Lars Dɪᴇᴄᴋᴏᴡ 迪拉斯 <daxim@cpan.org> Lars Dieckow <daxim@cpan.org>

--- a/dist.ini
+++ b/dist.ini
@@ -265,7 +265,9 @@ Test::Warnings        = 0.016
 
 [Prereqs::AuthorDeps]
 relation = suggests
+exclude = inc::CheckAuthorDeps
 exclude = inc::CheckDelta
+exclude = inc::CheckReleaseType
 exclude = inc::Clean
 exclude = inc::ExtractInlineTests
 exclude = inc::GenerateDocs
@@ -273,6 +275,7 @@ exclude = inc::GitUpToDate
 exclude = inc::MMHelper
 exclude = inc::MakeMaker
 exclude = inc::MyInline
+exclude = inc::SimpleAuthority
 exclude = inc::SimpleProvides
 exclude = inc::TestRelease
 


### PR DESCRIPTION
These dependencies are like the others, included in the bundle itself
and are effectively unindexed self-dependencies.

Currently they show up here: https://metacpan.org/source/ETHER/Moose-2.1403/META.json#L186 
