### PR TITLE
Improve method modifier's wrapper name

### DIFF
--- a/lib/Class/MOP/Method/Wrapped.pm
+++ b/lib/Class/MOP/Method/Wrapped.pm
@@ -86,13 +86,12 @@ sub wrap {
     $_build_wrapped_method->($modifier_table);
 
     # get these from the original unless explicitly overridden
-    my $pkg_name     = $params{package_name} || $code->package_name;
-    my $method_name  = $params{name}         || $code->name;
-    my $wrapped_name = "${pkg_name}::_wrapped_${method_name}";
+    my $pkg_name    = $params{package_name} || $code->package_name;
+    my $method_name = $params{name}         || $code->name;
 
     return $class->SUPER::wrap(
         sub {
-            my $wrapped = subname $wrapped_name => $modifier_table->{cache};
+            my $wrapped = subname "${pkg_name}::_wrapped_${method_name}" => $modifier_table->{cache};
             return $wrapped->(@_) ;
         },
         package_name    => $pkg_name,

--- a/lib/Class/MOP/Method/Wrapped.pm
+++ b/lib/Class/MOP/Method/Wrapped.pm
@@ -85,6 +85,7 @@ sub wrap {
     };
     $_build_wrapped_method->($modifier_table);
 
+    # get these from the original unless explicitly overridden
     my $pkg_name     = $params{package_name} || $code->package_name;
     my $method_name  = $params{name}         || $code->name;
     my $wrapped_name = "${pkg_name}::_wrapped_${method_name}";
@@ -94,13 +95,10 @@ sub wrap {
             my $wrapped = subname $wrapped_name => $modifier_table->{cache};
             return $wrapped->(@_) ;
         },
-        # get these from the original
-        # unless explicitly overridden
-        package_name   => $pkg_name,
-        name           => $method_name,
+        package_name    => $pkg_name,
+        name            => $method_name,
         original_method => $code,
-
-        modifier_table => $modifier_table,
+        modifier_table  => $modifier_table,
     );
 }
 

--- a/t/cmop/method_modifiers.t
+++ b/t/cmop/method_modifiers.t
@@ -214,13 +214,8 @@ use Class::MOP::Method;
     extends 'Parent';
 
     after 'something' => sub {
-        my $self = shift;
-        $self->boom;
-    };
-
-    sub boom {
         confess 'boom';
-    }
+    };
 }
 {
     my @errors;


### PR DESCRIPTION
At the moment, using method modifiers creates an anonymous sub that wraps the method. Thus, when a method modifier dies, the stacktrace contains only the generic `Class::MOP::Class:::after` (note the 3 colons) and the `__ANON__`, which doesn't help a lot in finding the triggering code. 

I understand from the comment near `Class::MOP::Class::add_around_method_modifier` (currently here: https://github.com/moose/Moose/blob/master/lib/Class/MOP/Class.pm#L1114) , that the method modifier itself cannot be named sensibly as it can be applied multiple times to different methods. However, the wrapper function created by `Class::MOP::Method::Wrapped::wrap` is unique for each method and should not suffer this limitation.

Please take a look at the patch, whether you think it's a valuable improvement to the work done by @autarch in 9ef07cddf93c6834e04be77a19dca6baca09cec0... It doesn't add any new dependencies as `Sub::Name` is already required.