### PR TITLE
Small cleanups around TC validation & exceptions

### DIFF
--- a/lib/Moose/Exception/ValidationFailedForTypeConstraint.pm
+++ b/lib/Moose/Exception/ValidationFailedForTypeConstraint.pm
@@ -19,15 +19,14 @@ has 'type' => (
 
 sub _build_message {
     my $self = shift;
-    my $error_message = $self->type->get_message($self->value);
 
-    if( $self->is_attribute_set )
-    {
-        my $attribute_name = $self->attribute->name;
-        return "Attribute ($attribute_name) does not pass the type constraint because: $error_message";
-    }
+    my $error = $self->type->get_message( $self->value );
 
-    return $error_message;
+    return $error unless $self->is_attribute_set;
+
+    my $attribute_name = $self->attribute->name;
+    return
+        "Attribute ($attribute_name) does not pass the type constraint because: $error";
 }
 
 1;

--- a/lib/Moose/Meta/TypeConstraint.pm
+++ b/lib/Moose/Meta/TypeConstraint.pm
@@ -206,15 +206,15 @@ sub inline_environment {
 }
 
 sub assert_valid {
-    my ($self, $value) = @_;
+    my ( $self, $value ) = @_;
 
-    my $error = $self->validate($value);
-    return 1 if ! defined $error;
+    return 1 if $self->check($value);
 
-    throw_exception( ValidationFailedForTypeConstraint => type          => $self,
-                                                          error_message => $error,
-                                                          value         => $value
-                   );
+    throw_exception(
+        'ValidationFailedForTypeConstraint',
+        type  => $self,
+        value => $value
+    );
 }
 
 sub get_message {

--- a/t/attributes/type_constraint.t
+++ b/t/attributes/type_constraint.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+
+{
+    package AttrHasTC;
+    use Moose;
+    has foo => (
+        is  => 'ro',
+        isa => 'Int',
+    );
+
+    has bar => (
+        is  => 'ro',
+    );
+}
+
+ok(
+    AttrHasTC->meta->get_attribute('foo')->verify_against_type_constraint(42),
+    'verify_against_type_constraint returns true with valid Int'
+);
+
+my $e = exception {
+    AttrHasTC->meta->get_attribute('foo')
+        ->verify_against_type_constraint('foo');
+};
+
+isa_ok(
+    $e,
+    'Moose::Exception::ValidationFailedForTypeConstraint',
+    'exception thrown when verify_against_type_constraint fails'
+);
+
+ok(
+    AttrHasTC->meta->get_attribute('bar')->verify_against_type_constraint(42),
+    'verify_against_type_constraint returns true when attr has no TC'
+);
+
+done_testing;


### PR DESCRIPTION
I also added tests for Moose::Meta::Attribute->verify_against_type_constraint as this method wasn't being explicitly tested at all.
