### PR TITLE
Moose/Exporter.pm: make sure uniq() always see a true array

### DIFF
--- a/lib/Moose/Exporter.pm
+++ b/lib/Moose/Exporter.pm
@@ -148,7 +148,7 @@ sub _follow_also {
 
     _die_if_cycle_found_in_also_list_for_package($exporting_package);
 
-    return uniq( _follow_also_real($exporting_package) );
+    return uniq( my @tmp = _follow_also_real($exporting_package) );
 }
 
 sub _follow_also_real {


### PR DESCRIPTION
FYI you might want to know that with Moose 2.1403 and List::MoreUtils 0.407 (c.f. [1]), I observed things like this:
```
t/bugs/traits_with_exporter.t .................................... Use of uninitialized value $package in hash element at /home/jdurand/.cpan/build/Moose-2.1403-zSM06q/blib/lib/Moose/Exporter.pm line 245.
Use of uninitialized value $package in concatenation (.) or string at /home/jdurand/.cpan/build/Moose-2.1403-zSM06q/blib/lib/Moose/Exporter.pm line 245.
The  package does not use Moose::Exporter
```

This pull request can be rejected, no pb, but how to say, this is to inform you and give a workaround that should be a priori stable v.s. uniq() quite tricky behaviour.

[1] https://rt.cpan.org/Ticket/Display.html?id=102840