### PR TITLE
steal MooseX::Does::Delegated

### DIFF
--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -236,10 +236,18 @@ sub does_via_delegation {
 
     # liberally borrowed from TOBYINK's MooseX::Does::Delegated
     for my $attr ($self->get_all_attributes) {
+        # Skip things unless we're actually delegating
         next unless $attr->can('handles') && $attr->can('has_handles') && $attr->has_handles;
+
+        # Empty attribute non-lazy attributes can't have delegation
+        next unless $attr->has_value($self) || $attr->is_lazy;
+
+        # Now delegation comes in several forms but they basically boil down to references
+        # and non-references (i.e. Class and Role names). We only care about the latter.
+        # If it matches either the role name, or the handles is a metaobject that does the
+        # role in question ... we're good
         my $handles = $attr->handles;
         next if ref $handles;
-        next unless $attr->has_value($self) || $attr->is_lazy;
         return 1 if $role_name eq $handles;
         return 1 if Class::MOP::class_of($handles)->does_role($role_name);
     }

--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -228,6 +228,25 @@ sub calculate_all_roles_with_inheritance {
              $self->linearized_isa;
 }
 
+sub does_via_delegation {
+    my ($self, $role_name) = @_;
+
+    (defined $role_name)
+        || throw_exception( RoleNameRequired => class_name => $self->name );
+
+    # liberally borrowed from TOBYINK's MooseX::Does::Delegated
+    for my $attr ($self->get_all_attributes) {
+        next unless $attr->can('handles') && $attr->can('has_handles') && $attr->has_handles;
+        my $handles = $attr->handles;
+        next if ref $handles;
+        next unless $attr->has_value($self) || $attr->is_lazy;
+        return 1 if $role_name eq $handles;
+        return 1 if Class::MOP::class_of($handles)->does_role($role_name);
+    }
+
+    return 0;
+}
+
 sub does_role {
     my ($self, $role_name) = @_;
 

--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -924,6 +924,12 @@ adds it to the class's list of role applications. This I<does not>
 actually apply any role to the class; it is only for tracking role
 applications.
 
+=item B<< $metaclass->does_via_delegation($role) >>
+
+This returns a boolean indicating whether or not the class does the specified
+role via a delegated attribute. The role provided can be either a role name or
+a L<Moose::Meta::Role> object. This tests both delegation to roles and classes.
+
 =item B<< $metaclass->does_role($role) >>
 
 This returns a boolean indicating whether or not the class does the specified

--- a/lib/Moose/Object.pm
+++ b/lib/Moose/Object.pm
@@ -121,6 +121,7 @@ sub does {
     (defined $role_name)
         || Moose::Util::throw_exception( DoesRequiresRoleName => class_name => $meta->name );
     return 1 if $meta->can('does_role') && $meta->does_role($role_name);
+    return 1 if $meta->can('does_via_delegation') && $meta->does_via_delegation($role_name);
     return 0;
 }
 

--- a/t/roles/does_via_delegation.t
+++ b/t/roles/does_via_delegation.t
@@ -1,4 +1,5 @@
 use strict;
+use warnings;
 use Test::More;
 
 {

--- a/t/roles/does_via_delegation.t
+++ b/t/roles/does_via_delegation.t
@@ -1,0 +1,36 @@
+use strict;
+use Test::More;
+
+{
+        package HttpGet;
+        use Moose::Role;
+        requires 'get';
+};
+
+{
+        package UserAgent;
+        use Moose;
+        with qw( HttpGet );
+        sub get { 1 };
+};
+
+{
+        package Spider;
+        use Moose;
+        has ua => (
+                is         => 'ro',
+                does       => 'HttpGet',
+                handles    => 'HttpGet',
+                lazy_build => 1,
+        );
+        sub _build_ua { UserAgent->new };
+};
+
+my $woolly = Spider->new;
+
+# Make sure that the Delegated roles show up
+
+ok( $woolly->DOES('Spider') );
+ok( $woolly->DOES('HttpGet') );
+
+done_testing;


### PR DESCRIPTION
The behavior in [MooseX::Does::Delegated][mdd] really should be a core
behavior of Moose. So we'll just borrow it wholesale (and it's tests)
and implement it in Moose directly.

[mdd]: https://metacpan.org/pod/MooseX::Does::Delegated