### PR TITLE
Tweak the perltidyrc and make with_immutable use subtests

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [ENHANCEMENTS]
+
+  - Test::Moose::with_immutable now runs each iteration of the test block in a
+    Test::More::subtest().
+
 2.1500   2015-06-30 (TRIAL RELEASE)
 
   [ENHANCEMENTS]

--- a/dist.ini
+++ b/dist.ini
@@ -254,7 +254,7 @@ skip = ^Moose::Meta::TypeConstraint::Union$
 [Prereqs / TestRequires]
 Test::CleanNamespaces = 0.13
 Test::Fatal           = 0.001
-Test::More            = 0.88
+Test::More            = 0.94
 Test::Requires        = 0.05
 Test::Warnings        = 0.016
 

--- a/lib/Test/Moose.pm
+++ b/lib/Test/Moose.pm
@@ -8,7 +8,8 @@ use Sub::Exporter;
 use Test::Builder;
 
 use List::Util 1.33 'all';
-use Moose::Util 'does_role', 'find_meta';
+use Moose::Util 'does_role', 'english_list', 'find_meta';
+use Test::More;
 
 my @exports = qw[
     meta_ok
@@ -73,9 +74,22 @@ sub with_immutable (&@) {
     my $block = shift;
     my $before = $Test->current_test;
 
-    $block->(0);
+    my $classes = english_list(@_);
+    my $verb = @_ > 1 ? 'are' : 'is';
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    subtest(
+        "$classes $verb not immutable",
+        sub {
+            $block->(0);
+        }
+    );
     Class::MOP::class_of($_)->make_immutable for @_;
-    $block->(1);
+    subtest(
+        "$classes $verb immutable",
+        sub {
+            $block->(1);
+        }
+    );
 
     my $num_tests = $Test->current_test - $before;
     my $all_passed = all { $_ } ($Test->summary)[-$num_tests..-1];
@@ -126,6 +140,9 @@ does for the methods.
 
 Runs B<CODE> (which should contain normal tests) twice, and make each
 class in C<@class_names> immutable in between the two runs.
+
+Each run of the B<CODE> block is run in its own subtest, and the subtests
+names indicate whether or not the classes are immutable or not.
 
 The B<CODE> block is called with a single boolean argument indicating whether
 or not the classes have been made immutable yet.

--- a/perltidyrc
+++ b/perltidyrc
@@ -15,7 +15,8 @@
 -nolq
 -npro
 -nsfs
---opening-hash-brace-right
---no-outdent-long-comments 
 --blank-lines-before-packages=0
+--opening-hash-brace-right
+--no-outdent-long-comments
+--iterations=2
 -wbb="% + - * / x != == >= <= =~ !~ < > | & >= < = **= += *= &= <<= &&= -= /= |= >>= ||= .= %= ^= x="

--- a/t/test_moose/with_immutable.t
+++ b/t/test_moose/with_immutable.t
@@ -16,21 +16,47 @@ use Test::Moose;
     use Moose;
 }
 
-package main;
+{
+    my @expect = split /\n/, <<'EOF';
+    # Subtest: Foo is not immutable
+    ok 1
+    1..1
+ok 1 - Foo is not immutable
+    # Subtest: Foo is immutable
+    not ok 1
+    1..1
+not ok 2 - Foo is immutable
+EOF
 
-test_out("ok 1", "not ok 2");
-test_fail(+2);
-my $ret = with_immutable {
-    ok(Foo->meta->is_mutable);
-} qw(Foo);
-test_test('with_immutable failure');
-ok(!$ret, "one of our tests failed");
+    test_out(@expect);
+    test_fail(+4);
+    my $ret = with_immutable {
+        ok( Foo->meta->is_mutable );
+    }
+    qw(Foo);
+    test_test('with_immutable failure');
+    ok( !$ret, 'one of our tests failed' );
+}
 
-test_out("ok 1", "ok 2");
-$ret = with_immutable {
-    ok(Bar->meta->find_method_by_name('new'));
-} qw(Bar);
-test_test('with_immutable success');
-ok($ret, "all tests succeeded");
+{
+    my @expect = split /\n/, <<'EOF';
+    # Subtest: Bar is not immutable
+    ok 1
+    1..1
+ok 1 - Bar is not immutable
+    # Subtest: Bar is immutable
+    ok 1
+    1..1
+ok 2 - Bar is immutable
+EOF
+
+    test_out(@expect);
+    my $ret = with_immutable {
+        ok( Bar->meta->find_method_by_name('new') );
+    }
+    qw(Bar);
+    test_test('with_immutable success');
+    ok( $ret, "all tests succeeded" );
+}
 
 done_testing;


### PR DESCRIPTION
I don't know if anyone besides me is *using* the perltidyrc (though I wish they would), but we might as well make it work better.

The test change should improve test output a bit when using with_immutable.