### PR TITLE
Make error messages for setting with a reader more awesome

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,10 +5,11 @@ for, noteworthy changes.
 
   [ENHANCEMENTS]
 
-  - When attempting to erronously set an attribute with a read-only accessor the
-    Moose::Exception::CannotAssignValueToReadOnlyAccessor error raised now has
-    an error message containing the name of the writer accessor that you
-    probably meant to call if such an accessor exists (Mark Fowler)
+  - When attempting to erroneously set an attribute with a read-only accessor
+    the Moose::Exception::CannotAssignValueToReadOnlyAccessor error raised now
+    is more informative if a writer accessor exists, suggesting that that writer
+    be used and supplying the name of the writer if it is non private (i.e.
+    doesn't start with an underscore).
 
 2.1500   2015-06-30 (TRIAL RELEASE)
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,13 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [ENHANCEMENTS]
+
+  - When attempting to erronously set an attribute with a read-only accessor the
+    Moose::Exception::CannotAssignValueToReadOnlyAccessor error raised now has
+    an error message containing the name of the writer accessor that you
+    probably meant to call if such an accessor exists (Mark Fowler)
+
 2.1500   2015-06-30 (TRIAL RELEASE)
 
   [ENHANCEMENTS]

--- a/lib/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm
+++ b/lib/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm
@@ -17,11 +17,14 @@ has 'suggested_writer' => (
     predicate => 'has_suggested_writer',
 );
 
+my $MESSAGE = "Cannot assign a value to a read-only accessor";
+
 sub _build_message {
     my $self = shift;
-    return "Cannot assign a value to a read-only accessor"
-        unless $self->has_suggested_writer;
-    return "Cannot assign a value to a read-only accessor (did you mean to call the '".$self->suggested_writer."' writer?)";
+    return $MESSAGE unless $self->has_suggested_writer;
+    return "$MESSAGE (did you mean to call the private writer?)"
+        if $self->suggested_writer =~ /\A_/;
+    return "$MESSAGE (did you mean to call the '".$self->suggested_writer."' writer?)";
 }
 
 1;

--- a/lib/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm
+++ b/lib/Moose/Exception/CannotAssignValueToReadOnlyAccessor.pm
@@ -1,5 +1,5 @@
 package Moose::Exception::CannotAssignValueToReadOnlyAccessor;
-our $VERSION = '2.1501'; # TRIAL
+our $VERSION = '2.1501';
 
 use Moose;
 extends 'Moose::Exception';
@@ -11,9 +11,17 @@ has 'value' => (
     required => 1
 );
 
+has 'suggested_writer' => (
+    is        => 'ro',
+    isa       => 'Str',
+    predicate => 'has_suggested_writer',
+);
+
 sub _build_message {
     my $self = shift;
-    "Cannot assign a value to a read-only accessor";
+    return "Cannot assign a value to a read-only accessor"
+        unless $self->has_suggested_writer;
+    return "Cannot assign a value to a read-only accessor (did you mean to call the '".$self->suggested_writer."' writer?)";
 }
 
 1;

--- a/t/exceptions/class-mop-method-accessor.t
+++ b/t/exceptions/class-mop-method-accessor.t
@@ -278,9 +278,10 @@ use Moose();
         "x is read only");
 }
 
-# we need to do this test as well as the moose one before so we can
-# test the non-inlined accessors (since if we test with moose straight
-# away we'll only test non-inlined accessors)
+# we need to test both with and without moose to get full test coverage
+# so we can test both the inlined and non inlined version of the generated
+# accessor.  This is because Moose always uses the inlined accessor code
+
 {
     {
         package CupOfTea;

--- a/t/exceptions/class-mop-method-accessor.t
+++ b/t/exceptions/class-mop-method-accessor.t
@@ -276,4 +276,54 @@ use Moose();
         120,
         "x is read only");
 }
+
+{
+    {
+        package CupOfTea;
+        use metaclass;
+
+        CupOfTea->meta->add_attribute('sugars' => (
+            reader   => 'sugars',
+            writer   => 'set_sugars',
+            init_arg => 'sugars'
+        ));
+
+        sub new {
+            my $class = shift;
+            bless $class->meta->new_object(@_) => $class;
+        }
+    }
+
+    my $cup_of_tea = CupOfTea->new();
+
+    my $exception = exception {
+        $cup_of_tea->sugars(2);
+    };
+
+    like(
+        $exception,
+        qr/\QCannot assign a value to a read-only accessor (did you mean to call the 'set_sugars' writer?)\E/,
+        "sugars is read only");
+
+    isa_ok(
+        $exception,
+        "Moose::Exception::CannotAssignValueToReadOnlyAccessor",
+        "sugars is read only");
+
+    is(
+        $exception->class_name,
+        "CupOfTea",
+        "sugars is read only");
+
+    is(
+        $exception->attribute_name,
+        "sugars",
+        "sugars is read only");
+
+    is(
+        $exception->value,
+        2,
+        "sugars is read only");
+}
+
 done_testing;


### PR DESCRIPTION
Several times I've been bitten by Moose telling me that I'm using a read only accessor even when the attribute is 'rw' because something has set a custom writer.  The error messages aren't awesome.

With these changes when attempting to erroneously set an attribute with a read-only accessor the Moose::Exception::CannotAssignValueToReadOnlyAccessor error raised now is more informative if a writer accessor exists, suggesting that that writer be used and supplying the name of the writer if it is non private (i.e. doesn't start with an underscore).
