### PR TITLE
Add reference to Moose attributes manual in Moose::Manual::Roles

### DIFF
--- a/lib/Moose/Manual/Roles.pod
+++ b/lib/Moose/Manual/Roles.pod
@@ -186,7 +186,7 @@ As mentioned before, a role's required method may also be satisfied by an
 attribute accessor. However, the call to C<has> which defines an attribute
 happens at runtime. This means that you must define the attribute I<before>
 consuming the role, or else the role will not see the generated accessor.
-These attributes are L<Moose Attributes|https://metacpan.org/pod/Moose::Manual::Attributes>
+These attributes are L<Moose Attributes|Moose::Manual::Attributes>
 
   package Breakable;
 

--- a/lib/Moose/Manual/Roles.pod
+++ b/lib/Moose/Manual/Roles.pod
@@ -186,6 +186,7 @@ As mentioned before, a role's required method may also be satisfied by an
 attribute accessor. However, the call to C<has> which defines an attribute
 happens at runtime. This means that you must define the attribute I<before>
 consuming the role, or else the role will not see the generated accessor.
+These attributes are L<Moose Attributes|https://metacpan.org/pod/Moose::Manual::Attributes>
 
   package Breakable;
 


### PR DESCRIPTION
I stumbled onto Moose::Manual::Roles, having very little knowledge of Moose and having never used it. It could be useful to add this link so that people can find out what attirbutes the required attributes section is referring to.

Sorry if this is the wrong branch to make a PR on, but I couldn't find the contributing documentation.