### PR TITLE
Correct C<> formatted text

### DIFF
--- a/lib/Moose.pm
+++ b/lib/Moose.pm
@@ -497,7 +497,7 @@ is expected to have consumed.
 
 This marks the attribute as being required. This means a value must be
 supplied during class construction, I<or> the attribute must be lazy
-and have either a default or a builder. Note that c<required> does not
+and have either a default or a builder. Note that C<required> does not
 say anything about the attribute's value, which can be C<undef>.
 
 =item I<weak_ref =E<gt> (1|0)>


### PR DESCRIPTION
This fixes a code formatting statement to use a capital 'C' instead of a
lower-case 'c'; the text will then be rendered correctly on e.g.
metacpan.org.

This pull request is submitted in the hope that it is helpful.  Questions and/or comments are more than welcome!