### PR TITLE
converted Moose::Util::does_role to use UNIVERSAL::DOES

### DIFF
--- a/lib/Moose/Util.pm
+++ b/lib/Moose/Util.pm
@@ -66,8 +66,8 @@ sub is_role {
 sub does_role {
     my ($class_or_obj, $role) = @_;
 
-    if (try { $class_or_obj->isa('Moose::Object') }) {
-        return $class_or_obj->does($role);
+    if (defined $class_or_obj) {
+        return $class_or_obj->DOES($role);
     }
 
     my $meta = find_meta($class_or_obj);


### PR DESCRIPTION
Perhaps simpler. Will allow more Interoperability with other role systems like Moo. For example using Test::Moose::does_ok may now work with a class that has a Moo role applied via Moo::Role->apply_roles_to_object().