### PR TITLE
add link to original source of the roles concept

### DIFF
--- a/lib/Moose/Manual/Roles.pod
+++ b/lib/Moose/Manual/Roles.pod
@@ -18,7 +18,9 @@ consumes the role. These attributes and methods then appear as if they
 were defined in the class itself. A subclass of the consuming class
 will inherit all of these methods and attributes.
 
-Moose roles are similar to mixins or interfaces in other languages.
+Moose roles are similar to mixins or interfaces in other languages and are
+based on the L<original concept of Traits|http://scg.unibe.ch/research/traits/>
+for the Smalltalk-80 dialect Squeak.
 
 Besides defining their own methods and attributes, roles can also
 require that the consuming class define certain methods of its


### PR DESCRIPTION
While trying to explain roles to some people i found myself looking for the original literature from which Roles stem and found that some of the links to it (via use.perl.org) have become dead in the meantime. As such, it might be helpful to have a direct link in the docs here.