### PR TITLE
Fix an incorrect usage of Data::OptList::mkopt

### DIFF
--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -107,7 +107,9 @@ sub _anon_cache_key {
 
     my $roles = Data::OptList::mkopt(($options{roles} || []), {
         moniker  => 'role',
-        val_test => sub { ref($_[0]) eq 'HASH' },
+        name_test => sub {
+            ! ref $_[0] or blessed($_[0]) && $_[0]->isa('Moose::Meta::Role')
+        },
     });
 
     my @role_keys;


### PR DESCRIPTION
[Data::OptList::mkopt](https://metacpan.org/pod/Data::OptList#mkopt) doesn't have a `val_test` option. Instead it has a `name_test` option.
To fix this issue in Moose::Meta::Class I copied a similar usage for a list of roles, from Moose::Util. I have no idea how the code is triggered and so no idea about how to write a test case.
