### PR TITLE
fix method cache generation when package contains blessed subs

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,10 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [TESTS]
+
+  - restore test on perl 5.8.x when Class::C3::XS is not installed (RT#113704)
+
 2.1703   2016-04-12 (TRIAL RELEASE)
 
   [TESTS]

--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  - Fixed method cache regeneration when a class contains a blessed sub
+    (RT#113704)
+
   [TESTS]
 
   - restore test on perl 5.8.x when Class::C3::XS is not installed (RT#113704)

--- a/t/cmop/methods.t
+++ b/t/cmop/methods.t
@@ -4,12 +4,6 @@ use warnings;
 use Test::More;
 use Test::Fatal;
 
-BEGIN {
-    # see RT#113704
-    plan skip_all => 'Need Class::C3::XS, at least for these tests, when mro is not available'
-        if $] < '5.010' and not eval { require Class::C3::XS; 1 };
-}
-
 use Scalar::Util qw/reftype/;
 use Sub::Name;
 

--- a/t/cmop/methods.t
+++ b/t/cmop/methods.t
@@ -101,6 +101,12 @@ is( exception {
   $Foo->add_method('bork', $bork_blessed);
 }, undef, 'can add blessed sub as method');
 
+$Foo->reset_package_cache_flag;
+
+is( exception {
+  $Foo->has_method('bork');
+}, undef, 'regeneration of method cache works after adding blessed sub as method');
+
 # now check all our other items ...
 
 ok( $Foo->has_method('FOO_CONSTANT'),

--- a/xs/HasMethods.xs
+++ b/xs/HasMethods.xs
@@ -24,7 +24,7 @@ mop_update_method_map(pTHX_ HV *const stash, HV *const map)
             continue;
         }
 
-        if (sv_isobject(method)) {
+        if (sv_derived_from(method, "Class::MOP::Method")) {
             /* $method_object->body() */
             body = mop_call0(aTHX_ method, KEY_FOR(body));
         }


### PR DESCRIPTION
When generating the method cache, the code was trying to call ->body on
it if it was an object.  The add_method code had previously been fixed
to only call ->body on meta objects rather than anything blessed.  The
XS code was only checking for objects being making that call.  This was
masked by method cache being kept up to date.

If the method cache is out of date though, this can crash.  The cache
can be intentionally reset, or we may not be able to track its status
properly (perl 5.8 without Class::C3::XS).

Fixes [RT#113704](https://rt.cpan.org/Ticket/Display.html?id=113704)

One thing I'm not certain of is that I'm using sv_derived_from to check for Class::MOP::Method objects.  This is roughly equivalent to `UNIVERSAL::isa($o, "Class::MOP::Method")`, rather than  `$o->isa("Class::MOP::Method")`.  If we want to use the actual method call I'll leave that up to someone else, as I'm not confident in my XS skills.