### PR TITLE
Clean up a few Specio special cases

### DIFF
--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -324,21 +324,12 @@ sub _process_isa_option {
 
     # allow for anon-subtypes here ...
     #
-    # Checking for Specio explicitly is completely revolting. At some point
-    # this needs to be refactored so that Moose core defines a standard type
-    # API that all types must implement. Unfortunately, the current core API
-    # is _not_ the right API, so we probably need to A) come up with the new
-    # API (Specio is a good start); B) refactor the core types to implement
-    # that API; C) do duck type checking on type objects.
+    # There are a _lot_ of methods that we expect from TC objects, but
+    # checking for a specific parent class via ->isa is gross, so we'll check
+    # for at least one method.
     if ( blessed( $options->{isa} )
-        && $options->{isa}->isa('Moose::Meta::TypeConstraint') ) {
-        $options->{type_constraint} = $options->{isa};
-    }
-    elsif (
-        blessed( $options->{isa} )
-        && $options->{isa}->can('does')
-        && $options->{isa}->does('Specio::Constraint::Role::Interface')
-        ) {
+        && $options->{isa}->can('has_coercion') ) {
+
         $options->{type_constraint} = $options->{isa};
     }
     else {
@@ -357,7 +348,8 @@ sub _process_does_option {
 
     # allow for anon-subtypes here ...
     if ( blessed( $options->{does} )
-        && $options->{does}->isa('Moose::Meta::TypeConstraint') ) {
+        && $options->{does}->can('has_coercion') ) {
+
         $options->{type_constraint} = $options->{does};
     }
     else {

--- a/lib/Moose/Meta/Method/Accessor/Native/Collection.pm
+++ b/lib/Moose/Meta/Method/Accessor/Native/Collection.pm
@@ -87,9 +87,7 @@ sub _check_new_members_only {
     # not Paramet_erized_), we don't know what is being checked by the
     # constraint, so we need to check the whole value, not just the members.
     return 1
-        if $self->_is_root_type( $tc->parent )
-            && ( $tc->isa('Moose::Meta::TypeConstraint::Parameterized')
-                 || $tc->isa('Specio::Constraint::Parameterized') );
+        if $self->_is_root_type( $tc->parent ) && !$tc->can('parameterize');
 
     return 0;
 }


### PR DESCRIPTION
I'd like to leave Specio support in Moose for a while longer, but there are a least a couple spots where we don't need to check for it specifically.