### PR TITLE
adding TODO test for failing MooX::HandlesVia with Moose 2.1802

### DIFF
--- a/t/todo_tests/MooX-HandlesVia_clear.t
+++ b/t/todo_tests/MooX-HandlesVia_clear.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Test::Requires {
+    'Moo::Role'        => '0',
+    'MooX::HandlesVia' => '0.001008',
+    'Types::Standard'  => '0',
+};
+
+eval {
+    do {
+        # works with Moose 2.1801, fails with Moose 2.1802
+        package MyRole {
+
+            use Moo::Role;
+            use MooX::HandlesVia;
+            use Types::Standard qw/ HashRef Str /;
+            has foo => (
+                is          => 'ro',
+                isa         => HashRef [Str],
+                handles_via => 'Hash',
+                handles     => { clear_foo => 'clear', },
+            );
+        }
+
+        package MyClass {
+            use Moose;
+            with 'MyRole';
+        }
+    };
+};
+
+TODO: {
+    local $TODO = 'Fix failing MooX::HandlesVia Hash clear';
+    ok !$@, "Used MooX::HandleVia handles => Hash 'clear' successfully";
+}
+
+done_testing();
+


### PR DESCRIPTION
Upgrading from 2.1801 to 2.1802 caused code using MooX::HandlesVia to fail.

Code in question (t/response.t for Role::REST::Client) is using "clear" for Data::Perl::Collection::Hash::MooseLike

https://metacpan.org/source/KAARE/Role-REST-Client-0.18/t/response.t

details of error:
https://gist.github.com/mjemmeson/6608d5b0ff0acf867b141229bd165807


# moose

```
( day changed to 31 May 2016 )
( 12:42      michael  ) hi, not sure if this is a problem with Moose or MooX::HandlesVia, but going from Moose 2.1801 to 2.1802 seems to have broken the Hash "clear" delegation
                        through MooX::HandlesVia - example: https://gist.github.com/mjemmeson/6608d5b0ff0acf867b141229bd165807
( 12:43      michael  ) Not very familiar with this, that has been extracted from a test for Role::REST::Client which is failing under 2.1802
( 13:36 @perigrin ) if you're using _Moose_ why not use the native attributes build into Moose?
( 13:36 @perigrin ) Ahh I see becausse you're using a Moo::Role
( 13:40     perigrin@ ) michael: check your versions on MooX::HandlesVia .... I can't see anything in the six commits bwteen 2.1801 and 2.1802 that would cause that
( 13:42     perigrin@ ) michael: https://github.com/moose/Moose/commit/f18f44c9dde825f9e80264a26f22773967940d6d is litterally the only _code_ change between those two releases
                        afaict
( 13:42 @perigrin ) and I can't see how it would cause the behavior you're seeing.
( 13:50      michael  ) thanks - i couldn't see how change that between 2.1801 and 2.1802 mattered either. This isn't my code btw, this is Role::REST::Client's tests failing
( 13:52      michael  ) ran that code with 2.1801 and 2.1802 with same MooX::HandlesVia (0.001008 - the most recent)
( 13:58 @perigrin ) weird
( 14:00     perigrin@ ) michael: can you turn it into a failing test at the very least for Moose and submit that via a PR?
( 14:00 @perigrin ) That way it won't get lost.
```