### PR TITLE
fix using Type::Tiny types with native traits

### DIFF
--- a/lib/Moose/Meta/Method/Accessor/Native/Collection.pm
+++ b/lib/Moose/Meta/Method/Accessor/Native/Collection.pm
@@ -87,7 +87,9 @@ sub _check_new_members_only {
     # not Paramet_erized_), we don't know what is being checked by the
     # constraint, so we need to check the whole value, not just the members.
     return 1
-        if $self->_is_root_type( $tc->parent ) && !$tc->can('parameterize');
+        if $self->_is_root_type( $tc->parent )
+            && ( $tc->isa('Moose::Meta::TypeConstraint::Parameterized')
+                 || !$tc->can('parameterize') );
 
     return 0;
 }

--- a/t/type_constraints/with-type-tiny.t
+++ b/t/type_constraints/with-type-tiny.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+
+use Test::Requires 'Types::Standard';
+
+is exception {
+    package MyClass;
+
+    use Moose;
+    use Types::Standard qw/ HashRef Str /;
+    has foo => (
+        is      => 'ro',
+        isa     => HashRef[Str],
+        traits  => [ 'Hash' ],
+        handles => { clear_foo => 'clear' },
+    );
+}, undef,
+    'Type::Tiny usable with native traits';
+
+done_testing;


### PR DESCRIPTION
Type::Tiny has code to fake being various Moose classes.  Unfortunately,
it doesn't fully emulate those when checked via can, either for positive
or negative checks.  Reintroduce the check for our internal expected
class, but keep the !parameterize check for use by things like Specio.

This fixes the problem shown in #125, which isn't directly related to MooX::HandlesVia.