### PR TITLE
Add more docs on attr inheritance and method modifiers

### DIFF
--- a/lib/Moose/Manual/Attributes.pod
+++ b/lib/Moose/Manual/Attributes.pod
@@ -563,6 +563,16 @@ to C<'Bill'>.
 We recommend that you exercise caution when changing the type (C<isa>)
 of an inherited attribute.
 
+=head2 Attribute Inheritance and Method Modifiers
+
+When an inherited attribute is defined, that creates an entirely new set of
+accessors for the attribute (reader, writer, predicate, etc.). This is
+necessary because these may be what was changed when inheriting the attribute.
+
+As a consequence, any method modifiers defined on the attribute's accessors in
+an ancestor class will effectively be ignored, because the new accessors live
+in the child class and do not see the modifiers from the parent class.
+
 =head1 MULTIPLE ATTRIBUTE SHORTCUTS
 
 If you have a number of attributes that differ only by name, you can declare


### PR DESCRIPTION
Method modifiers in the parent class's attr accessors don't apply in the child
when it overrides a parent class's attribute, because we generate new
accessors.

This partially addresses https://rt.cpan.org/Ticket/Display.html?id=79572