### PR TITLE
Inline delegations when possible

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,15 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [ENHANCEMENTS}
+
+  - Most delegations are inlined now. This is not done for speed but rather to
+    improve stack traces when the delegated-to method throws an exception or
+    when the delegated-to method simply does not exist in the
+    delegatee. Previously, this stack trace and associated error were less
+    helpful than they could have been. Requested by Tim Bunce, Olaf Alders,
+    and Van de Bugger. (RT#46614, RT#98402, and RT#109631).
+
 2.1805   2016-08-19
 
   [BUG FIXES]

--- a/lib/Class/MOP/Method.pm
+++ b/lib/Class/MOP/Method.pm
@@ -143,6 +143,15 @@ sub clone {
     return $clone;
 }
 
+sub _inline_throw_exception {
+    my ( $self, $exception_type, $throw_args ) = @_;
+    return
+          'die Module::Runtime::use_module("Moose::Exception::'
+        . $exception_type
+        . '")->new('
+        . ( $throw_args || '' ) . ')';
+}
+
 1;
 
 # ABSTRACT: Method Meta Object

--- a/lib/Class/MOP/Method/Accessor.pm
+++ b/lib/Class/MOP/Method/Accessor.pm
@@ -169,11 +169,6 @@ sub _generate_reader_method_inline {
     };
 }
 
-sub _inline_throw_exception {
-    my ( $self, $exception_type, $throw_args ) = @_;
-    return 'die Module::Runtime::use_module("Moose::Exception::' . $exception_type . '")->new(' . ($throw_args || '') . ')';
-}
-
 sub _generate_writer_method {
     my $self = shift;
     my $attr = $self->associated_attribute;

--- a/t/exceptions/moose-meta-method-delegation.t
+++ b/t/exceptions/moose-meta-method-delegation.t
@@ -151,23 +151,25 @@ use Moose();
     like(
         $exception,
         qr/\QCannot delegate get_count to count because the value of foo is not an object (got '$array')/,
-        "value of foo is an ARRAY ref");
-        #Cannot delegate get_count to count because the value of foo is not an object (got 'ARRAY(0x223f578)')
+        'exception thrown when trying to delegate to an unblessed ref'
+    );
 
     isa_ok(
         $exception,
-        "Moose::Exception::AttributeValueIsNotAnObject",
-        "value of foo is an ARRAY ref");
+        'Moose::Exception::AttributeValueIsNotAnObject',
+    );
 
     is(
         $exception->given_value,
         $array,
-        "value of foo is an ARRAY ref");
+        'exception contains the attribute value'
+    );
 
     is(
         $exception->attribute->name,
         "foo",
-        "value of foo is an ARRAY ref");
+        'exception contains the attribute'
+    );
 }
 
 done_testing;


### PR DESCRIPTION
This has two benefits ...

1. A stack trace from inside the delegated method is much more helpful since
it skips Moose guts.

2. When the delegated-to method does not exist, the error message includs
information about exactly what class, attribute, and delegated method was
called.

3. It allows for MX modules to hook into attribute delegation inlining, which
was apparently something we talked about at $work some time back.