### PR TITLE
Fixed issue where a role generated on the fly could not be used as a …

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,12 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES}
+
+  - A role generated on the fly (as opposed to one in a file on disk) could
+    not be used as a trait. Fixed by Aaron Cohen. (RT#92089, PR#47).
+
+
 2.1805   2016-08-19
 
   [BUG FIXES]

--- a/lib/Moose/Util.pm
+++ b/lib/Moose/Util.pm
@@ -4,7 +4,7 @@ our $VERSION = '2.1806';
 use strict;
 use warnings;
 
-use Module::Runtime 0.014 'use_package_optimistically', 'use_module', 'module_notional_filename';
+use Module::Runtime 0.014 'use_package_optimistically', 'module_notional_filename';
 use Data::OptList;
 use Params::Util qw( _STRING );
 use Sub::Exporter;
@@ -144,7 +144,7 @@ sub _apply_all_roles {
             $meta = $role->[0];
         }
         else {
-            &use_module($role->[0], $role->[1] && $role->[1]{-version} ? $role->[1]{-version} : ());
+            _load_user_class( $role->[0] , $role->[1] );
             $meta = find_meta( $role->[0] );
         }
 

--- a/t/bugs/find_custom_trait_rt_92089.t
+++ b/t/bugs/find_custom_trait_rt_92089.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+
+{
+    package Custom::Trait;
+    use Moose::Role;
+
+    my $alias         = 'Trait1';
+    my $new_role_name = __PACKAGE__ . "::$alias";
+    Moose::Meta::Role->initialize($new_role_name);
+    Moose::Exporter->setup_import_methods(
+        exporting_package => $new_role_name );
+    Moose::Util::meta_attribute_alias( $alias, $new_role_name );
+}
+
+is(
+    exception {
+        package Foo;
+        use Moose;
+        use Custom::Trait;
+
+        has field1 => ( is => 'rw', traits => [qw{Trait1}] );
+
+        Foo->new;
+    },
+    undef,
+    'Trait that is not an on-disk role works'
+);
+
+like(
+    exception {
+        package Bar;
+        use Moose;
+        use Custom::Trait;
+
+        has field1 => ( is => 'rw', traits => [qw{UndeclaredTrait}] );
+        Bar->new;
+    },
+    qr/\QCan't locate Moose::Meta::Attribute::Custom::Trait::UndeclaredTrait or UndeclaredTrait/,
+    'Traits with no alias or package cause an exception'
+);
+
+done_testing();

--- a/t/exceptions/util.t
+++ b/t/exceptions/util.t
@@ -97,7 +97,7 @@ use Moose::Util qw/apply_all_roles add_method_modifier/;
 
     like(
         $exception,
-        qr!Can't locate Not/A/Real/Package\.pm in \@INC!,
+        qr!You can only consume roles, Not::A::Real::Package is not a Moose role!,
         "You can't consume a class which doesn't exist");
 
     $exception = exception {


### PR DESCRIPTION
…trait

This is a cleaned up version of #47 