### PR TITLE
Improve the description of inlined delegation subs

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [ENHANCEMENTS]
+
+  - The stack trace for an inlined delegation now tells you where the
+    delegating attribute was declared (file and line number).
+
 2.1901   2016-10-20 (TRIAL RELEASE)
 
   [TESTS]
@@ -12,7 +17,7 @@ for, noteworthy changes.
 
 2.1900   2016-10-09 (TRIAL RELEASE)
 
-  [ENHANCEMENTS}
+  [ENHANCEMENTS]
 
   - Most delegations are inlined now. This is not done for speed but rather to
     improve stack traces when the delegated-to method throws an exception or

--- a/lib/Moose/Meta/Method/Delegation.pm
+++ b/lib/Moose/Meta/Method/Delegation.pm
@@ -130,13 +130,18 @@ sub {
 }
 EOF
 
+    my $definition = $attr->definition_context;
+    my $description
+        = 'inline delegation in '
+        . $self->package_name . ' for '
+        . $attr->name . '->'
+        . $delegate
+        . " (attribute declared in $definition->{file} at line $definition->{line})";
+
     return try {
         $self->_compile_code(
             source      => $source,
-            description => 'inline delegation in '
-                . $self->package_name . ' for '
-                . $attr->name . '->'
-                . $delegate
+            description => $description,
         );
     }
     catch {

--- a/t/attributes/attribute_delegation.t
+++ b/t/attributes/attribute_delegation.t
@@ -504,10 +504,18 @@ is($car->stop, 'Engine::stop', '... got the right value from ->stop');
 
 {
     # https://rt.cpan.org/Ticket/Display.html?id=98402
+    my $e = exception { DelegatesToThrower->new->throw };
+
     unlike(
-        exception { DelegatesToThrower->new->throw },
+        $e,
         qr{Moose(?:/|::)},
         'stack trace from inside delegated-to method does not include Moose when delegation is inlined'
+    );
+    my $file = __FILE__;
+    like(
+        $e,
+        qr{ in DelegatesToThrower for thrower->throw \(attribute declared in $file at line \d+\)},
+        'stack trace tells you where delegation was defined'
     );
 }
 


### PR DESCRIPTION
The description is used in stack traces so we now get something like this:

    Thrower::throw(Thrower=HASH(0x34245f8)) called at inline delegation in
    DelegatesToThrower for thrower->throw (attribute declared in
    t/attributes/attribute_delegation.t at line 501) line 18

This should make it much easier to figure out what happened when a delegated
method fails.