### PR TITLE
Minor doc changes Moose::Manual::MethodModifiers.pm

### DIFF
--- a/lib/Moose/Manual/MethodModifiers.pod
+++ b/lib/Moose/Manual/MethodModifiers.pod
@@ -186,7 +186,7 @@ modifiers of the superclass, as the following example illustrates:
 
 Here is the parent class:
 
-  package Progenitor;
+  package Superclass;
   use Moose;
   sub rant { printf "        RANTING!\n" }
   before 'rant' => sub { printf "    In %s before\n", __PACKAGE__ };
@@ -202,9 +202,9 @@ Here is the parent class:
 
 And the child class:
 
-  package Child;
+  package Subclass;
   use Moose;
-  extends 'Progenitor';
+  extends 'Superclass';
   before 'rant' => sub { printf "In %s before\n", __PACKAGE__ };
   after 'rant'  => sub { printf "In %s after\n",  __PACKAGE__ };
   around 'rant' => sub {
@@ -218,17 +218,17 @@ And the child class:
 
 And here's the output when we call the wrapped method (C<< Child->rant >>):
 
-  % perl -MChild -e 'Child->new->rant'
+  % perl -MSubclass -e 'Subclass->new->rant'
 
-  In Child before
-    In Child around before calling original
-      In Progenitor before
-        In Progenitor around before calling original
+  In Subclass before
+    In Subclass around before calling original
+      In Superclass before
+        In Superclass around before calling original
           RANTING!
-        In Progenitor around after calling original
-      In Progenitor after
-    In Child around after calling original
-  In Child after
+        In Superclass around after calling original
+      In Superclass after
+    In Subclass around after calling original
+  In Subclass after
 
 =head1 INNER AND AUGMENT
 

--- a/lib/Moose/Manual/MethodModifiers.pod
+++ b/lib/Moose/Manual/MethodModifiers.pod
@@ -31,6 +31,7 @@ It's probably easiest to understand this feature with a few examples:
 
       print "  I'm still around foo\n";
   };
+  1;
 
 Now if I call C<< Example->new->foo >> I'll get the following output:
 
@@ -185,7 +186,7 @@ modifiers of the superclass, as the following example illustrates:
 
 Here is the parent class:
 
-  package Parent;
+  package Progenitor;
   use Moose;
   sub rant { printf "        RANTING!\n" }
   before 'rant' => sub { printf "    In %s before\n", __PACKAGE__ };
@@ -203,7 +204,7 @@ And the child class:
 
   package Child;
   use Moose;
-  extends 'Parent';
+  extends 'Progenitor';
   before 'rant' => sub { printf "In %s before\n", __PACKAGE__ };
   after 'rant'  => sub { printf "In %s after\n",  __PACKAGE__ };
   around 'rant' => sub {
@@ -221,11 +222,11 @@ And here's the output when we call the wrapped method (C<< Child->rant >>):
 
   In Child before
     In Child around before calling original
-      In Parent before
-        In Parent around before calling original
+      In Progenitor before
+        In Progenitor around before calling original
           RANTING!
-        In Parent around after calling original
-      In Parent after
+        In Progenitor around after calling original
+      In Progenitor after
     In Child around after calling original
   In Child after
 


### PR DESCRIPTION
First example Example was missing a true at the end. Renamed Parent.pm to Progenitor.pm so that it works on OS X. Parent.pm conflicts with
parent.pm.