### PR TITLE
add compatibility shim: _get_delegate_accessor()

### DIFF
--- a/lib/Moose/Meta/Method/Delegation.pm
+++ b/lib/Moose/Meta/Method/Delegation.pm
@@ -84,6 +84,9 @@ sub _initialize_body {
     return;
 }
 
+# compatibility shim for traits expecting Moose < 2.019
+sub _get_delegate_accessor { ${ $_[0]->_get_delegate_accessor_ref } }
+
 sub _generate_inline_method {
     my $self = shift;
 

--- a/t/metaclasses/method-delegation-_get_delegate_accessor.t
+++ b/t/metaclasses/method-delegation-_get_delegate_accessor.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+{
+    package Foo;
+    use Moose;
+
+    sub foo { }
+}
+{
+    package Bar;
+    use Moose;
+
+    has foo     => (
+        is      => 'ro',
+        isa     => 'Foo',
+        handles => {
+            foo_foo => 'foo',
+        },
+    );
+}
+
+my $meta_method = Bar->meta->get_method('foo_foo');
+isa_ok $meta_method => 'Moose::Meta::Method::Delegation';
+cmp_ok $meta_method->_get_delegate_accessor, 'eq', ${ $meta_method->_get_delegate_accessor_ref },
+    'both coderefs are identical';
+
+done_testing;


### PR DESCRIPTION
_get_delegate_accessor() was removed and replaced with
_generate_inline_method() early in the 2.19 series...  Yet at least one
MooseX trait depends on this method.

Here we resurrect _get_delegate_accessor(), simply to maintain
compatibility.

See RsrchBoy/moosex-currieddelegation#1