### PR TITLE
Restore the MMM::Delegation->_get_delegate_access method

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,12 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  - Brought back the Moose::Meta::Method::Delegation->_get_delegate_accessor
+    method for the benefit of MooseX::CurriedDelegation.
+
+
 2.1902   2016-10-23 (TRIAL RELEASE)
 
   [ENHANCEMENTS]

--- a/lib/Moose/Meta/Method/Delegation.pm
+++ b/lib/Moose/Meta/Method/Delegation.pm
@@ -163,21 +163,21 @@ sub _eval_environment {
     }
 
     unless ( $self->associated_attribute->has_read_method ) {
-        $env{'$reader'} = $self->_get_delegate_accessor_ref;
+        $env{'$reader'} = \( $self->_get_delegate_accessor );
     }
 
     return \%env;
 }
 
-sub _get_delegate_accessor_ref {
+sub _get_delegate_accessor {
     my $self = shift;
 
     my $accessor = $self->associated_attribute->get_read_method_ref;
 
     # If it's blessed it's a Moose::Meta::Method
     return blessed $accessor
-        ? \( $accessor->body )
-        : \$accessor;
+        ? ( $accessor->body )
+        : $accessor;
 }
 
 1;


### PR DESCRIPTION
At least one MX module on CPAN was using it.