### PR TITLE
Warn on all attribute method name conflicts

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,16 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [ENHANCEMENTS]
+
+  - When an attribute defines two methods (say a reader and writer) with the
+    same name, this now generates a warning.
+
+  - The warning when attribute methods overwrite one another is now much more
+    informative. It includes the type of accessors involve (reader, writer,
+    predicate, etc.) as well as the file and line where each accessor was
+    defined. Fixes RT #118325.
+
   [BUG FIXES]
 
   - The definition context (package, file, & line) for attributes on

--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  - The definition context (package, file, & line) for attributes on
+    Class::MOP and Moose metaclasses was wrong in all cases.
+
 2.1902   2016-10-23 (TRIAL RELEASE)
 
   [ENHANCEMENTS]

--- a/lib/Class/MOP.pm
+++ b/lib/Class/MOP.pm
@@ -94,7 +94,7 @@ sub is_class_loaded {
 
 sub _definition_context {
     my %context;
-    @context{qw(package file line)} = caller(1);
+    @context{qw(package file line)} = caller(0);
 
     return (
         definition_context => \%context,

--- a/lib/Moose/Meta/Mixin/AttributeCore.pm
+++ b/lib/Moose/Meta/Mixin/AttributeCore.pm
@@ -36,7 +36,8 @@ __PACKAGE__->meta->add_attribute(
 
 __PACKAGE__->meta->add_attribute(
     'lazy' => (
-        reader => 'is_lazy', Class::MOP::_definition_context(),
+        reader => 'is_lazy',
+        Class::MOP::_definition_context(),
     )
 );
 

--- a/t/attributes/accessor_overwrite_warning.t
+++ b/t/attributes/accessor_overwrite_warning.t
@@ -5,6 +5,8 @@ use Test::More;
 
 use Test::Requires 'Test::Output';
 
+my $file = __FILE__;
+
 {
     package Bar;
     use Moose;
@@ -13,13 +15,42 @@ use Test::Requires 'Test::Output';
         is => 'ro',
     );
 
-    ::stderr_like{ has attr => (
-            is        => 'ro',
-            predicate => 'has_attr',
-        )
-        }
-        qr/\QYou are overwriting an accessor (has_attr) for the has_attr attribute with a new accessor method for the attr attribute/,
-        'overwriting an accessor for another attribute causes a warning';
+    ::stderr_like(
+        sub {
+            has attr => (
+                is        => 'ro',
+                predicate => 'has_attr',
+            );
+        },
+        qr/
+           \QYou are overwriting a reader (has_attr) for the has_attr attribute\E
+           \Q (defined at $file line \E\d+\)
+           \Q with a new predicate method for the attr attribute\E
+           \Q (defined at $file line \E\d+\)
+          /x,
+        'overwriting an accessor for another attribute causes a warning'
+    );
+}
+
+{
+    package Foo;
+    use Moose;
+
+    ::stderr_like(
+        sub {
+            has buz => (
+                reader => 'my_buz',
+                writer => 'my_buz',
+            );
+        },
+        qr/
+           \QYou are overwriting a reader (my_buz) for the buz attribute\E
+           \Q (defined at $file line \E\d+\)
+           \Q with a new writer method for the buz attribute\E
+           \Q (defined at $file line \E\d+\)
+          /x,
+        'overwriting an accessor for the same attribute causes a warning'
+    );
 }
 
 done_testing;

--- a/t/basics/definition_context.t
+++ b/t/basics/definition_context.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Moose;
+
+use Class::MOP::Class;
+use Moose::Meta::Class;
+use Moose::Meta::Attribute;
+
+my %tests = (
+    'Class::MOP::Class superclasses attribute' => {
+        attribute => Class::MOP::Class->meta->find_attribute_by_name('superclasses'),
+        package   => 'Class::MOP',
+        file      => $INC{'Class/MOP.pm'},
+
+        # This is obviously pretty fragile, so let's not test the line for
+        # more than one attribute.
+        line => 308,
+    },
+    'Moose::Meta::Class roles attribute' => {
+        attribute => Moose::Meta::Class->meta->find_attribute_by_name('roles'),
+        package   => 'Moose::Meta::Class',
+        file      => $INC{'Moose/Meta/Class.pm'},
+    },
+    'Moose::Meta::Attribute required attribute' => {
+        attribute => Moose::Meta::Attribute->meta->find_attribute_by_name('required'),
+        package   => 'Moose::Meta::Mixin::AttributeCore',
+        file      => $INC{'Moose/Meta/Mixin/AttributeCore.pm'},
+    },
+);
+
+for my $subtest ( sort keys %tests ) {
+    my $t = $tests{$subtest};
+    subtest(
+        $subtest,
+        sub {
+            my $c = $t->{attribute}->definition_context;
+            is( $c->{package}, $t->{package}, 'package' );
+            is( $c->{file},    $t->{file},    'file' );
+            if ( exists $t->{line} ) {
+                is( $c->{line}, $t->{line}, 'line' );
+            }
+        }
+    );
+}
+
+done_testing;


### PR DESCRIPTION
Previously we only warned when methods conflicted between two different attributes, but a single attribute could define any number of methods which conflicted and not get a warning.

I also fixed a *very* long-standing bug regarding the definition context for attributes on CMOP & Moose classes.