### PR TITLE
Testing/failure using subtype as object

### DIFF
--- a/t/attributes/misc_attribute_coerce_lazy.t
+++ b/t/attributes/misc_attribute_coerce_lazy.t
@@ -19,8 +19,8 @@ use Test::Fatal;
     use Moose;
     use Moose::Util::TypeConstraints;
 
-    subtype Header =>
-        => as Object
+    subtype Header
+        => as 'Object'
         => where { $_->isa('HTTPHeader') };
 
     coerce Header

--- a/t/attributes/misc_attribute_coerce_lazy.t
+++ b/t/attributes/misc_attribute_coerce_lazy.t
@@ -19,14 +19,14 @@ use Test::Fatal;
     use Moose;
     use Moose::Util::TypeConstraints;
 
-    subtype Header
+    subtype 'Header'
         => as 'Object'
         => where { $_->isa('HTTPHeader') };
 
-    coerce Header
-        => from ArrayRef
+    coerce 'Header'
+        => from 'ArrayRef'
             => via { HTTPHeader->new(array => $_[0]) }
-        => from HashRef
+        => from 'HashRef'
             => via { HTTPHeader->new(hash => $_[0]) };
 
     has 'headers'  => (

--- a/t/type_constraints/util_type_coercion.t
+++ b/t/type_constraints/util_type_coercion.t
@@ -14,14 +14,14 @@ use Moose::Util::TypeConstraints;
     has 'hash'  => (is => 'ro');
 }
 
-subtype Header
+subtype 'Header'
     => as 'Object'
     => where { $_->isa('HTTPHeader') };
 
-coerce Header
-    => from ArrayRef
+coerce 'Header'
+    => from 'ArrayRef'
         => via { HTTPHeader->new(array => $_[0]) }
-    => from HashRef
+    => from 'HashRef'
         => via { HTTPHeader->new(hash => $_[0]) };
 
 
@@ -38,9 +38,9 @@ my $anon_type = subtype Object => where { $_->isa('HTTPHeader') };
 
 is( exception {
     coerce $anon_type
-        => from ArrayRef
+        => from 'ArrayRef'
             => via { HTTPHeader->new(array => $_[0]) }
-        => from HashRef
+        => from 'HashRef'
             => via { HTTPHeader->new(hash => $_[0]) };
 }, undef, 'coercion of anonymous subtype succeeds' );
 

--- a/t/type_constraints/util_type_coercion.t
+++ b/t/type_constraints/util_type_coercion.t
@@ -14,8 +14,8 @@ use Moose::Util::TypeConstraints;
     has 'hash'  => (is => 'ro');
 }
 
-subtype Header =>
-    => as Object
+subtype Header
+    => as 'Object'
     => where { $_->isa('HTTPHeader') };
 
 coerce Header


### PR DESCRIPTION
Unaccountably, these tests failed causing the module install with cpanm to fail on a new perlbrew of 5.16.3. Was attempting to install Dist::Zilla as the first module. Hard to understand what actually triggered this for me - I don't see that any modules have created an 'Object' namespace, as suggested by the comments in `t/bugs/subtype_quote_bug.t`.