### PR TITLE
support __no_BUILD__

### DIFF
--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -485,6 +485,8 @@ sub _inline_BUILDALL {
     my $self = shift;
 
     my @methods = reverse $self->find_all_methods_by_name('BUILD');
+    return () unless @methods;
+
     my @BUILD_calls;
 
     foreach my $method (@methods) {
@@ -492,7 +494,11 @@ sub _inline_BUILDALL {
             '$instance->' . $method->{class} . '::BUILD($params);';
     }
 
-    return @BUILD_calls;
+    return (
+        'if (!$params->{__no_BUILD__}) {',
+        @BUILD_calls,
+        '}',
+    );
 }
 
 sub _eval_environment {

--- a/lib/Moose/Object.pm
+++ b/lib/Moose/Object.pm
@@ -49,6 +49,7 @@ sub BUILDALL {
     # extra meta level calls
     return unless $_[0]->can('BUILD');
     my ($self, $params) = @_;
+    return if $params->{__no_BUILD__};
     foreach my $method (reverse Class::MOP::class_of($self)->find_all_methods_by_name('BUILD')) {
         $method->{code}->execute($self, $params);
     }

--- a/t/metaclasses/new_object_BUILD.t
+++ b/t/metaclasses/new_object_BUILD.t
@@ -15,5 +15,9 @@ is($called, 1, "BUILD called from ->new");
 $called = 0;
 Foo->meta->new_object;
 is($called, 1, "BUILD called from ->meta->new_object");
+Foo->new({__no_BUILD__ => 1});
+is($called, 1, "BUILD not called from ->new with __no_BUILD__");
+Foo->meta->new_object({__no_BUILD__ => 1});
+is($called, 1, "BUILD not called from ->meta->new_object with __no_BUILD__");
 
 done_testing;


### PR DESCRIPTION
Add support for `__no_BUILD__` as a constructor argument to skip calling
any BUILD subs.  This is used by modules like Moo that have their own
implementation of calling BUILD.