### PR TITLE
Don't assume that definition_context is populated for methods or attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  - Moose could die when attempting to warn about overwriting an attribute's
+    access method in some cases (RT #120040)
+
 2.2002   2017-01-30
 
   [BUG FIXES]

--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -1059,18 +1059,38 @@ sub _process_accessors {
             my $other_attr = $method->associated_attribute;
 
             my $msg = sprintf(
-                'You are overwriting a %s (%s) for the %s attribute (defined at %s line %s)'
-                    . ' with a new %s method for the %s attribute (defined at %s line %s)',
+                'You are overwriting a %s (%s) for the %s attribute',
                 $method->accessor_type,
                 $accessor,
                 $other_attr->name,
-                $method->definition_context->{file},
-                $method->definition_context->{line},
+            );
+
+            if ( my $method_context = $method->definition_context ) {
+                $msg .= sprintf(
+                    ' (defined at %s line %s)',
+                    $method_context->{file},
+                    $method_context->{line},
+                    )
+                    if defined $method_context->{file}
+                    && $method_context->{line};
+            }
+
+            $msg .= sprintf(
+                ' with a new %s method for the %s attribute',
                 $type,
                 $self->name,
-                $self->definition_context->{file},
-                $self->definition_context->{line}
             );
+
+            if ( my $self_context = $self->definition_context ) {
+                $msg .= sprintf(
+                    ' (defined at %s line %s)',
+                    $self_context->{file},
+                    $self_context->{line},
+                    )
+                    if defined $self_context->{file}
+                    && $self_context->{line};
+            }
+
             Carp::cluck($msg);
         }
     }


### PR DESCRIPTION
The code that warned when overwriting an attribute's accessor would die if the
context was undefined, which is bad.