### PR TITLE
Fix a bug where Moose would try to create two accessors of the same name

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,14 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  - When an attribute was specified as 'rw' and you also provided an accessor
+    name matching the attribute and there was an explicit writer, Moose would
+    try to make an additional reader access with the same name as the
+    attribute. Then Moose would warn about overwriting an accessor with a
+    reader. This is related to the bugs reported in RT #120040.
+
 2.2003   2017-01-30
 
   [BUG FIXES]

--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -291,11 +291,13 @@ sub _process_is_option {
         $options->{reader} ||= $name;
     }
     elsif ( $options->{is} eq 'rw' ) {
-        if ( $options->{writer} ) {
-            $options->{reader} ||= $name;
-        }
-        else {
-            $options->{accessor} ||= $name;
+        if ( ! $options->{accessor} ) {
+            if ( $options->{writer}) {
+                $options->{reader} ||= $name;
+            }
+            else {
+                $options->{accessor} = $name;
+            }
         }
     }
     elsif ( $options->{is} eq 'bare' ) {

--- a/t/attributes/accessor_overwrite_warning.t
+++ b/t/attributes/accessor_overwrite_warning.t
@@ -53,4 +53,23 @@ my $file = __FILE__;
     );
 }
 
+{
+    package Baz;
+    use Moose;
+
+    # This tests where Moose would also make a reader named buz for this
+    # attribute, leading to an overwrite warning.
+    ::stderr_is(
+        sub {
+            has buz => (
+                is       => 'rw',
+                accessor => 'buz',
+                writer   => '_set_buz',
+            );
+        },
+        q{},
+        'no warning with rw attribute that has both an accessor and a writer'
+    );
+}
+
 done_testing;


### PR DESCRIPTION
An attribute like this:

```perl
  has foo => (
      is => 'rw',
      accessor => 'foo',
      writer   => '_set_foo',
  );
```

would lead to Moose making a reader named 'foo' as well as the accessor. This
would then cause Moose to warn about overwriting an accessor with a reader.