### PR TITLE
Fix an incorrect usage of Data::OptList::mkopt

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,13 @@ for, noteworthy changes.
 
 {{$NEXT}}
 
+  [BUG FIXES]
+
+  - Passing roles as a mix of role names and role objects to
+    Moose::Meta::class->create_anon_class could throw a bogus exception about
+    'Roles with parameters cannot be cached ...'. Fixed by Olivier
+    Mengué. Based on PR #117.
+
 2.2005   2017-05-03
 
   [OTHER]

--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -106,7 +106,9 @@ sub _anon_cache_key {
 
     my $roles = Data::OptList::mkopt(($options{roles} || []), {
         moniker  => 'role',
-        val_test => sub { ref($_[0]) eq 'HASH' },
+        name_test => sub {
+            ! ref $_[0] or blessed($_[0]) && $_[0]->isa('Moose::Meta::Role')
+        },
     });
 
     my @role_keys;

--- a/t/bugs/create_anon_mkopt.t
+++ b/t/bugs/create_anon_mkopt.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Moose::Meta::Class;
+
+{
+    package Class;
+    use Moose;
+
+    package Foo;
+    use Moose::Role;
+
+    package Bar;
+    use Moose::Role;
+}
+
+{
+    my $class_and_roles_1 = Moose::Meta::Class->create_anon_class(
+        superclasses => ['Class'],
+        roles        => ['Foo', 'Bar'],
+        cache        => 1,
+    );
+
+    # Our handling of roles in the Moose::Meta::Class->_anon_cache_key()
+    # method was broken because we were trying to use mkopt incorrectly. This
+    # was triggered by passing a list where a role name is followed by a role
+    # object. Prior to the bug fix this would have died with an error saying
+    # 'Roles with parameters cannot be cached ...'
+    my $class_and_roles_2 = Moose::Meta::Class->create_anon_class(
+        superclasses => ['Class'],
+        roles        => [ 'Foo', Bar->meta ],
+        cache        => 1,
+    );
+
+    is(
+        $class_and_roles_1->name,
+        $class_and_roles_2->name,
+        'caching works when roles are given as a mix of names and role objects'
+    );
+}
+
+done_testing();


### PR DESCRIPTION
The mkopt sub doesn't have a 'val_test' option. Instead it has a 'name_test'
option.

To fix this issue in Moose::Meta::Class I copied a similar usage for a list of
roles, from Moose::Util.