### PR TITLE
A required attribute can be provided by a non-lazy default

### DIFF
--- a/lib/Moose/Manual/Attributes.pod
+++ b/lib/Moose/Manual/Attributes.pod
@@ -41,7 +41,9 @@ The options passed to C<has> define the properties of the attribute. There are
 many options, but in the simplest form you just need to set C<is>, which can
 be either C<ro> (read-only) or C<rw> (read-write). When an attribute is C<rw>,
 you can change it by passing a value to its accessor. When an attribute is
-C<ro>, you may only read the current value of the attribute.
+C<ro>, you may only read the current value of the attribute through its
+accessor. You can, however, set the attribute when creating the object by
+passing it to the constructor.
 
 In fact, you could even omit C<is>, but that gives you an attribute
 that has no accessor. This can be useful with other attribute options,

--- a/lib/Moose/Manual/Attributes.pod
+++ b/lib/Moose/Manual/Attributes.pod
@@ -166,8 +166,8 @@ There are a couple caveats worth mentioning in regards to what
 "required" actually means.
 
 Basically, all it says is that this attribute (C<name>) must be provided to
-the constructor, or be lazy with either a default or a builder. It does not
-say anything about its value, so it could be C<undef>.
+the constructor or it must have either a default or a builder. It does not say
+anything about its value, so it could be C<undef>.
 
 If you define a clearer method on a required attribute, the clearer
 I<will> work, so even a required attribute can be unset after object


### PR DESCRIPTION
This fixes a doc bug reported in https://rt.cpan.org/Ticket/Display.html?id=121749