### PR TITLE
Remove bogus code in Moose::Meta::TypeConstraint::equals

### DIFF
--- a/lib/Moose/Meta/TypeConstraint.pm
+++ b/lib/Moose/Meta/TypeConstraint.pm
@@ -232,19 +232,7 @@ sub equals {
     my ( $self, $type_or_name ) = @_;
 
     my $other = Moose::Util::TypeConstraints::find_type_constraint($type_or_name);
-    return if not $other;
-
-    return 1 if $self == $other;
-
-    return unless $self->constraint == $other->constraint;
-
-    if ( $self->has_parent ) {
-        return unless $other->has_parent;
-        return unless $self->parent->equals( $other->parent );
-    } else {
-        return if $other->has_parent;
-    }
-
+    return 1 if ($other && $self == $other);
     return;
 }
 


### PR DESCRIPTION
While profiling some hot code I reviewed `Moose::Meta::TypeConstraint::equals`, and think that the lower half of it is bogus and can be removed:
After the single "return 1" of the method, all following code will return undef and does not have any other side effects as far as I can tell - so I think it can be safely dropped.
All unittests are happy - but please double-check, as I'm by no means an export on the Moose meta classes.