### PR TITLE
native traits: document contextual behavior of elements

### DIFF
--- a/lib/Moose/Meta/Attribute/Native/Trait/Array.pm
+++ b/lib/Moose/Meta/Attribute/Native/Trait/Array.pm
@@ -78,10 +78,13 @@ This method does not accept any arguments.
 
 =item * B<elements>
 
-Returns all of the elements of the array as an array (not an array reference).
+In list context, returns all of the elements of the array as a list.
 
-  my @option = $stuff->all_options;
-  print "@options\n";    # prints "foo bar baz boo"
+In scalar context, returns the number of elements in the array.
+
+  my @options = $stuff->all_options;
+  print "@options";    # prints "foo bar baz boo"
+  print scalar $stuff->all_options; # prints 4
 
 This method does not accept any arguments.
 

--- a/lib/Moose/Meta/Attribute/Native/Trait/Hash.pm
+++ b/lib/Moose/Meta/Attribute/Native/Trait/Hash.pm
@@ -102,7 +102,10 @@ This method does not accept any arguments.
 
 =head2 elements
 
-Returns the key/value pairs in the hash as a flattened list..
+In list context, this returns the key/value pairs in the hash.
+
+In scalar context, this returns the count of keys plus values.  In other words,
+it's the same as L<keys> times two.
 
 This method does not accept any arguments.
 


### PR DESCRIPTION
The docs of "returning something as an array" were not great.  Returns are lists and scalars.  This documents the specific behavior for the elements delegation.