### PR TITLE
remove internal modules from no_index list

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -142,19 +142,6 @@ meta_noindex = 1
 finder = ModulesSansPod ; to avoid "No namespaces detected in file..." spewage
 
 [MetaNoIndex]
-package   = Class::MOP::Class::Immutable::Trait
-package   = Class::MOP::Deprecated
-package   = Class::MOP::MiniTrait
-package   = Class::MOP::Mixin
-namespace = Class::MOP::Mixin
-package   = Moose::Deprecated
-package   = Moose::Meta::Attribute::Native::Trait
-package   = Moose::Meta::Class::Immutable::Trait
-package   = Moose::Meta::Method::Accessor::Native
-namespace = Moose::Meta::Method::Accessor::Native
-namespace = Moose::Meta::Mixin
-package   = Moose::Meta::Object::Trait
-package   = Moose::Util::TypeConstraints::Builtins
 directory = author
 directory = benchmarks
 directory = doc


### PR DESCRIPTION
Moose has many modules that are only meant for use internally.  They
have been marked as no_index, preventing them from showing up in
02packages.  This serves nearly no purpose.  Although we don't want
people to depend on the modules, it would often work anyway because the
files still exist on disk.  It also means that the permissions for the
packages are not captured, allowing others to claim them, possibly
unintentionally.