### PR TITLE
try catch will not parsed without ';'

### DIFF
--- a/lib/Moose/Manual/Exceptions.pod
+++ b/lib/Moose/Manual/Exceptions.pod
@@ -65,7 +65,7 @@ L<Moose::Exception::ExtendsMissingArgs>.
         else {
             warn "$e\n";
         }
-    }
+    };
 
 =head2 Example of catching ValidationFailedForTypeConstraint
 
@@ -132,7 +132,7 @@ L<Moose::Exception::ExtendsMissingArgs>.
             else {
                 warn "$e\n";
             }
-        }
+        };
     }
 
 =head2 Example of catching AttributeIsRequired


### PR DESCRIPTION
`try` `catch` will not parsed without ';'
These examples have misprints...