### PR TITLE
support method modifiers for overridden accessor

### DIFF
--- a/lib/Moose/Manual/Attributes.pod
+++ b/lib/Moose/Manual/Attributes.pod
@@ -565,16 +565,6 @@ to C<'Bill'>.
 We recommend that you exercise caution when changing the type (C<isa>)
 of an inherited attribute.
 
-=head2 Attribute Inheritance and Method Modifiers
-
-When an inherited attribute is defined, that creates an entirely new set of
-accessors for the attribute (reader, writer, predicate, etc.). This is
-necessary because these may be what was changed when inheriting the attribute.
-
-As a consequence, any method modifiers defined on the attribute's accessors in
-an ancestor class will effectively be ignored, because the new accessors live
-in the child class and do not see the modifiers from the parent class.
-
 =head1 MULTIPLE ATTRIBUTE SHORTCUTS
 
 If you have a number of attributes that differ only by name, you can declare

--- a/t/attributes/overrided_accessor_modifier.t
+++ b/t/attributes/overrided_accessor_modifier.t
@@ -1,0 +1,219 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+{
+    package Foo;
+
+    use Moose;
+
+    has 'foo' => (
+        is        => 'ro',
+        writer    => 'set_foo',
+        predicate => 'has_foo',
+    );
+
+    has 'set_foo_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    has 'has_foo_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    around 'has_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->has_foo_arounded($self->has_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'set_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->set_foo_arounded($self->set_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+}
+
+{
+    package MyFoo;
+
+    use Moose;
+
+    sub push { return; };
+}
+
+{
+    package Bar;
+
+    use Moose;
+
+    extends 'Foo';
+
+    has '+foo' => (
+        lazy => 0,
+    );
+
+    has 'bar' => (
+        is      => 'ro',
+        isa     => 'MyFoo',
+        reader  => 'get_bar',
+        default => sub { MyFoo->new(); },
+        handles => [qw/push/],
+    );
+
+    has 'get_bar_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    has 'bar_handle_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    around 'has_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->has_foo_arounded($self->has_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'set_foo' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->set_foo_arounded($self->set_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'get_bar' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->get_bar_arounded($self->get_bar_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'push' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->bar_handle_arounded($self->bar_handle_arounded + 1);
+
+        $self->$orig(@_);
+    };
+}
+
+{
+    package Baz;
+
+    use Moose;
+
+    extends 'Bar';
+
+    has '+bar' => (
+        lazy => 0,
+    );
+
+    around 'has_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->has_foo_arounded($self->has_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'get_bar' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->get_bar_arounded($self->get_bar_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'push' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->bar_handle_arounded($self->bar_handle_arounded + 1);
+
+        $self->$orig(@_);
+    };
+}
+
+{
+    my $foo = Foo->new;
+
+    isa_ok($foo, 'Foo');
+
+    $foo->has_foo();
+    $foo->set_foo(1);
+
+    is($foo->has_foo_arounded, 1, '... got hte correct value');
+    is($foo->set_foo_arounded, 1, '... got hte correct value');
+
+    my $bar = Bar->new;
+
+    isa_ok($bar, 'Bar');
+
+    $bar->has_foo();
+    is($bar->has_foo_arounded, 2, '... got hte correct value');
+
+    $bar->set_foo(1);
+    is($bar->set_foo_arounded, 2, '... got hte correct value');
+
+    $bar->get_bar();
+    is($bar->get_bar_arounded, 1, '... got hte correct value');
+
+    $bar->push(1);
+    # method delegation calls reader internally
+    # Moose/Meta/Method/Delegation.pm
+    is($bar->get_bar_arounded, 2, '... got hte correct value');
+    is($bar->bar_handle_arounded, 1, '... got hte correct value');
+
+    my $baz = Baz->new;
+
+    isa_ok($baz, 'Baz');
+
+    $baz->has_foo();
+    is($baz->has_foo_arounded, 3, '... got hte correct value');
+
+    $baz->set_foo(1);
+    is($baz->set_foo_arounded, 2, '... got hte correct value');
+
+    $baz->get_bar();
+    is($baz->get_bar_arounded, 2, '... got hte correct value');
+
+    $baz->push(1);
+    is($baz->get_bar_arounded, 4, '... got hte correct value');
+    is($baz->bar_handle_arounded, 2, '... got hte correct value');
+}
+
+done_testing;


### PR DESCRIPTION
method modifiers for overrided attribute's accessors(reader/writer/accessor) are not executed when I try to use method modifiers in child class for that.

```perl
#!/usr/bin/env perl 

{
    package My;

    use Moose;

    has 'name' =>
    (
        is      => 'ro',
        isa     => 'Str',
        default => 'noname',
        writer  => 'set_name',
    );

    around 'set_name' => sub
    {
        my $orig = shift;
        my $self = shift;

        print __PACKAGE__ . "::set_name\n";

        $self->$orig(@_);
    };
}

{
    package My::Child;

    use Moose;

    extends 'My';

    has '+name' =>
    (
        coerce => 1,
    );

    around 'set_name' => sub
    {
        my $orig = shift;
        my $self = shift;

        print __PACKAGE__ . "::set_name\n";

        $self->$orig(@_);
    };
}

my $mychild = My::Child->new();

printf "Name: %s\n", $mychild->set_name('potatogim');
```

```
# before
> perl test.pl
My::Child::set_name
Name: potatogim

# after
> perl test.pl
My::Child::set_name
My::set_name
Name: potatogim
```

```
# Test result
> make test
...
t/type_constraints/type_names.t .................................. ok   
t/type_constraints/type_notation_parser.t ........................ ok    
t/type_constraints/types_and_undef.t ............................. ok    
t/type_constraints/union_is_a_type_of.t .......................... ok    
t/type_constraints/union_types.t ................................. ok    
t/type_constraints/union_types_and_coercions.t ................... ok    
t/type_constraints/util_find_type_constraint.t ................... ok    
t/type_constraints/util_more_type_coercion.t ..................... ok    
t/type_constraints/util_std_type_constraints.t ................... ok      
t/type_constraints/util_type_coercion.t .......................... ok    
t/type_constraints/util_type_constraints.t ....................... ok     
t/type_constraints/util_type_constraints_export.t ................ ok   
t/type_constraints/util_type_reloading.t ......................... ok   
t/type_constraints/with-specio.t ................................. ok   
t/type_constraints/with-type-tiny.t .............................. ok   
All tests successful.
Files=477, Tests=17326, 161 wallclock secs ( 2.83 usr  0.66 sys + 146.96 cusr 10.50 csys = 160.95 CPU)
Result: PASS
```

Signed-off-by: Ji-Hyeon Gim <potatogim@gluesys.com>