### PR TITLE
Let people clear the default value of an attribute when inheriting

### DIFF
--- a/lib/Moose/Exception/BothAttributeAndClearAttributeAreNotAllowed.pm
+++ b/lib/Moose/Exception/BothAttributeAndClearAttributeAreNotAllowed.pm
@@ -1,0 +1,21 @@
+package Moose::Exception::BothAttributeAndClearAttributeAreNotAllowed;
+our $VERSION = '2.2013';
+
+use Moose;
+extends 'Moose::Exception';
+with 'Moose::Exception::Role::ParamsHash';
+
+has 'attribute_name' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1
+);
+
+sub _build_message {
+    my $self = shift;
+    return "You said both to clear_" . $self->attribute_name
+        . " and also to set a value for " . $self->attribute_name;
+}
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/Moose/Exception/InvalidClearedAttribute.pm
+++ b/lib/Moose/Exception/InvalidClearedAttribute.pm
@@ -1,0 +1,21 @@
+package Moose::Exception::InvalidClearedAttribute;
+our $VERSION = '2.2013';
+
+use Moose;
+extends 'Moose::Exception';
+with 'Moose::Exception::Role::ParamsHash';
+
+has 'attribute_name' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+sub _build_message {
+    my $self = shift;
+    "You said clear_" . $self->attribute_name . " but " . $self->attribute_name
+        . " is not the name of an existing attribute";
+}
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/Moose/Manual/Attributes.pod
+++ b/lib/Moose/Manual/Attributes.pod
@@ -597,7 +597,7 @@ this, prepend the attribute name with C<clear_>: e.g.
  
  use Moose;
  extends 'Person::Archaic';
- 
+
  has '+gender' => (
      is            => 'rw',
      clear_default => 1,

--- a/lib/Moose/Manual/Attributes.pod
+++ b/lib/Moose/Manual/Attributes.pod
@@ -575,6 +575,35 @@ As a consequence, any method modifiers defined on the attribute's accessors in
 an ancestor class will effectively be ignored, because the new accessors live
 in the child class and do not see the modifiers from the parent class.
 
+=head2 Clearing Aspects
+
+Sometimes, you may decide that you don't want to override an aspect of the
+original attribute with a new value; rather, you want there to be I<no value>.
+(For instance, the default would normally have been a value that is no longer
+valid; but undef or the empty string aren't valid either.) In situations like
+this, prepend the attribute name with C<clear_>: e.g.
+
+ person Person::Archaic;
+ 
+ use Moose;
+ 
+ has 'gender' => (
+     is      => 'ro',
+     isa     => 'Gender',
+     default => 'Male',
+ );
+ 
+ package Person::Modern;
+ 
+ use Moose;
+ extends 'Person::Archaic';
+ 
+ has '+gender' => (
+     is            => 'rw',
+     clear_default => 1,
+     required      => 1,
+ );
+
 =head1 MULTIPLE ATTRIBUTE SHORTCUTS
 
 If you have a number of attributes that differ only by name, you can declare

--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -251,7 +251,6 @@ sub clone {
     }
 
     ### TODO: can't say default => 'foo' and clear_default => 1
-    ### TODO: can't say clear_brush if brush isn't a valid attribute name
     ### TODO: test that clear_attribute_name if attribute_name isn't set
     ### does nothing.
     for my $param_name (keys %params) {
@@ -259,6 +258,10 @@ sub clone {
             my $cleared_attr_name = $1;
             if ($attr_by_name{$cleared_attr_name}) {
                 delete $new_params{$cleared_attr_name};
+            } else {
+                throw_exception( InvalidClearedAttribute => attribute_name => $cleared_attr_name,
+                                                            params         => \%params
+                               );
             }
         } else {
             $new_params{$param_name} = $params{$param_name};

--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -250,8 +250,6 @@ sub clone {
         }
     }
 
-    ### TODO: test that clear_attribute_name if attribute_name isn't set
-    ### does nothing.
     for my $param_name (keys %params) {
         if ($param_name =~ /^ clear_ (.+) /x) {
             my $cleared_attr_name = $1;

--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -254,7 +254,7 @@ sub clone {
         if ($param_name =~ /^ clear_ (.+) /x) {
             my $cleared_attr_name = $1;
             if ($attr_by_name{$cleared_attr_name}) {
-                if ($params{$cleared_attr_name}) {
+                if (exists $params{$cleared_attr_name}) {
                     throw_exception( BothAttributeAndClearAttributeAreNotAllowed => attribute_name => $cleared_attr_name,
                                                                                     params => \%params
                                    );

--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -250,13 +250,17 @@ sub clone {
         }
     }
 
-    ### TODO: can't say default => 'foo' and clear_default => 1
     ### TODO: test that clear_attribute_name if attribute_name isn't set
     ### does nothing.
     for my $param_name (keys %params) {
         if ($param_name =~ /^ clear_ (.+) /x) {
             my $cleared_attr_name = $1;
             if ($attr_by_name{$cleared_attr_name}) {
+                if ($params{$cleared_attr_name}) {
+                    throw_exception( BothAttributeAndClearAttributeAreNotAllowed => attribute_name => $cleared_attr_name,
+                                                                                    params => \%params
+                                   );
+                }
                 delete $new_params{$cleared_attr_name};
             } else {
                 throw_exception( InvalidClearedAttribute => attribute_name => $cleared_attr_name,

--- a/t/attributes/attribute_inherited_slot_specs.t
+++ b/t/attributes/attribute_inherited_slot_specs.t
@@ -120,6 +120,9 @@ use Test::Fatal;
 
     extends 'Foo';
 
+    ::like( ::exception {
+        has '+bar' => (clear_brush => 'I live in Texas, I just do this')
+    }, qr/You said clear_brush but/, 'Cannot clear a non-existent attribute');
     ::is( ::exception {
         has '+bar' => (clear_default => 1);
     }, undef, 'Can clear a previous default');

--- a/t/attributes/attribute_inherited_slot_specs.t
+++ b/t/attributes/attribute_inherited_slot_specs.t
@@ -114,6 +114,15 @@ use Test::Fatal;
     ::like( ::exception {
         has '+does_not_exist' => (isa => 'Str');
     }, qr/in Bar/, '... cannot extend a non-existing attribute' );
+
+    package Foo::VagueBar;
+    use Moose;
+
+    extends 'Foo';
+
+    ::is( ::exception {
+        has '+bar' => (clear_default => 1);
+    }, undef, 'Can clear a previous default');
 }
 
 my $foo = Foo->new;
@@ -190,6 +199,12 @@ is($bar->baz, undef, '... got the right undef default value');
     my $code_ref = sub { 1 };
     isnt( exception { $bar->baz($code_ref) }, undef, '... Bar::baz does not accept a code ref' );
 }
+
+my $foo_vaguebar = Foo::VagueBar->new;
+isa_ok($foo_vaguebar, 'Foo::VagueBar');
+isa_ok($foo_vaguebar, 'Foo');
+ok(!$foo_vaguebar->meta->find_attribute_by_name('bar')->has_value($foo_vaguebar),
+    'An attribute whose definition gets rid of a default value does not have a value');
 
 # check some meta-stuff
 

--- a/t/attributes/attribute_inherited_slot_specs.t
+++ b/t/attributes/attribute_inherited_slot_specs.t
@@ -121,8 +121,12 @@ use Test::Fatal;
     extends 'Foo';
 
     ::like( ::exception {
-        has '+bar' => (clear_brush => 'I live in Texas, I just do this')
+        has '+bar' => (clear_brush => 'I live in Texas, I just do this');
     }, qr/You said clear_brush but/, 'Cannot clear a non-existent attribute');
+    ::like( ::exception {
+        has '+bar' => (clear_default => 1, default => 'Something reasonable');
+    }, qr/You said both to clear_default and also to set a value for default/,
+       'Must be consistent: default value or no default value?');
     ::is( ::exception {
         has '+bar' => (clear_default => 1);
     }, undef, 'Can clear a previous default');

--- a/t/attributes/attribute_inherited_slot_specs.t
+++ b/t/attributes/attribute_inherited_slot_specs.t
@@ -115,6 +115,10 @@ use Test::Fatal;
         has '+does_not_exist' => (isa => 'Str');
     }, qr/in Bar/, '... cannot extend a non-existing attribute' );
 
+    ::is( ::exception {
+        has '+baz' => (clear_default => 1),
+    }, undef, 'Can trivially clear an already-cleared attribute');
+
     package Foo::VagueBar;
     use Moose;
 

--- a/t/attributes/attribute_inherited_slot_specs.t
+++ b/t/attributes/attribute_inherited_slot_specs.t
@@ -127,10 +127,16 @@ use Test::Fatal;
     ::like( ::exception {
         has '+bar' => (clear_brush => 'I live in Texas, I just do this');
     }, qr/You said clear_brush but/, 'Cannot clear a non-existent attribute');
+    my $re_make_up_your_mind
+        = qr/You said both to clear_default and also to set a value for default/;
     ::like( ::exception {
         has '+bar' => (clear_default => 1, default => 'Something reasonable');
-    }, qr/You said both to clear_default and also to set a value for default/,
+    }, $re_make_up_your_mind,
        'Must be consistent: default value or no default value?');
+   ::like( ::exception {
+       has '+bar' => (clear_default => 1, default => 0);
+   }, $re_make_up_your_mind,
+      '...including when the new default value is false');
     ::is( ::exception {
         has '+bar' => (clear_default => 1);
     }, undef, 'Can clear a previous default');


### PR DESCRIPTION
When attempting to [fix MooseX::LazyRequire so you can turn it on and off in a sub-class](https://github.com/moose/MooseX-LazyRequire/pull/1), I came up against the problem that when you inherit from a parent class's attribute, you can't delete an existing key; you can only replace it.

And no, replacing an existing default value with `undef` isn't the same as there being no default, in the same way that any Moose object's attribute having the explicit value `undef` is different from it not having a value at all. I remember seeing documentation that claimed that somewhere, but unfortunately I haven't been able to track that down since I realised its mistake.

I appreciate that the note to contributors says (I paraphrase) "we won't add any new features; please consider a MooseX module instead". I tried going down the MooseX route when patching MooseX::LazyRequire, but the problem seems to be a bit *too* deep in the guts of Moose for that?

I've tried to adhere to existing standards when it comes to exceptions, but I'll confess I haven't gone through every single exception in detail. Similarly, I've tried to match the coding style, but this is a new codebase to me so I'm sure there are things I've missed.

I haven't considered which other attributes of an attribute you might want to clear like this, on top of default. I don't even know if there *are* any attributes like default, where you have a tripartite value of defined / undefined / non-existent. OTOH, it's a commonplace that the best software is that which is used for a purpose that its authors didn't intend.