### PR TITLE
Fix non-Moose union type constraints

### DIFF
--- a/lib/Moose/Util/TypeConstraints.pm
+++ b/lib/Moose/Util/TypeConstraints.pm
@@ -74,21 +74,21 @@ sub create_type_constraint_union {
 
 sub create_named_type_constraint_union {
     my $name = shift;
-    _create_type_constraint_union($name, \@_);
+    _create_type_constraint_union(\@_, { name => $name });
 }
 
 sub _create_type_constraint_union {
-    my $name;
-    $name = shift if @_ > 1;
-    my @tcs = @{ shift() };
+    my ( $tcs, $options ) = @_;
+    $options //= {};
+    my $name = $options->{name};
 
     my @type_constraint_names;
 
-    if ( scalar @tcs == 1 && _detect_type_constraint_union( $tcs[0] ) ) {
-        @type_constraint_names = _parse_type_constraint_union( $tcs[0] );
+    if ( scalar @$tcs == 1 && _detect_type_constraint_union( $tcs->[0] ) ) {
+        @type_constraint_names = _parse_type_constraint_union( $tcs->[0] );
     }
     else {
-        @type_constraint_names = @tcs;
+        @type_constraint_names = @$tcs;
     }
 
     ( scalar @type_constraint_names >= 2 )

--- a/lib/Moose/Util/TypeConstraints.pm
+++ b/lib/Moose/Util/TypeConstraints.pm
@@ -80,7 +80,9 @@ sub create_named_type_constraint_union {
 sub _create_type_constraint_union {
     my ( $tcs, $options ) = @_;
     $options //= {};
+
     my $name = $options->{name};
+    my $creator = $options->{creator};
 
     my @type_constraint_names;
 
@@ -95,7 +97,7 @@ sub _create_type_constraint_union {
         || throw_exception("UnionTakesAtleastTwoTypeNames");
 
     my @type_constraints = map {
-        find_or_parse_type_constraint($_)
+        find_or_parse_type_constraint($_, $creator ? { creator => $creator } : ())
             || throw_exception( CouldNotLocateTypeConstraintForUnion => type_name => $_ );
     } @type_constraint_names;
 
@@ -269,7 +271,10 @@ sub find_or_parse_type_constraint {
         return $constraint;
     }
     elsif ( _detect_type_constraint_union($type_constraint_name) ) {
-        $constraint = create_type_constraint_union($type_constraint_name);
+        $constraint = _create_type_constraint_union(
+            [ $type_constraint_name ],
+            $creator ? { creator => $creator } : ()
+        );
     }
     elsif ( _detect_parameterized_type_constraint($type_constraint_name) ) {
         $constraint

--- a/t/attributes/attribute_type_unions_non_moose.t
+++ b/t/attributes/attribute_type_unions_non_moose.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+
+{
+    package TestAlgoAA;
+    sub new { return bless {}, shift }
+
+    package TestAlgoBB;
+    sub new { return bless {}, shift }
+
+    package Foo;
+    use Moose;
+
+    ::is( ::exception { has 'bar' => (is => 'rw', isa => 'TestAlgoAA | TestAlgoBB') }, undef, "can have union of non-Moose classes" );
+}
+
+my $foo = Foo->new;
+isa_ok($foo, 'Foo');
+
+is( exception {
+    $foo->bar(TestAlgoAA->new)
+}, undef, 'set bar successfully with unions\' first type' );
+
+is( exception {
+    $foo->bar(TestAlgoBB->new)
+}, undef, 'set bar successfully with unions\' second type' );
+
+done_testing;


### PR DESCRIPTION
It's currently not possible to reference non-Moose classes in union types if Moose has not yet registered the type constraints.
I.e. this works:
```perl
has 'bar' => (is => 'rw', isa => 'TestAlgoAA');
has 'bar' => (is => 'rw', isa => 'TestAlgoBB');
```
but this doesn't:
```perl
has 'bar' => (is => 'rw', isa => 'TestAlgoAA | TestAlgoBB');
# Could not locate type constraint (TestAlgoAA) for the union
```
The cause is the current logic of type parsing / lookup `Moose::Util::TypeConstraints`.
I fixed it by slightly shifting functionality and extending some methods.

Tests are passing. I will try and run `test-my-dependents.t` on a decent machine soon and post the results.