### PR TITLE
detect list of UNIVERSAL methods rather than hard coding list

### DIFF
--- a/t/cmop/methods.t
+++ b/t/cmop/methods.t
@@ -198,8 +198,10 @@ is_deeply(
     '... got the right method list for Foo'
 );
 
-my @universal_methods = qw/isa can VERSION/;
-push @universal_methods, 'DOES' if "$]" >= 5.010;
+my @universal_methods = grep {
+    no strict 'refs';
+    !/::$/ && defined &{"UNIVERSAL::$_"}
+} keys %UNIVERSAL::;
 
 is_deeply(
     [


### PR DESCRIPTION
We don't need to keep our own list of methods in UNIVERSAL, we can just use the actual list of methods that exists. Some things, like the import method, could end up existing based on the perl version or based on a prerequite loading UNIVERSAL.pm. There isn't really any value in keeping a hard coded list.