### PR TITLE
remove test checking namespace::autoclean against Test::CleanNamespaces

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -315,7 +315,6 @@ code = s{^(note 'Checking Changes')}{if \(\(\$ENV\{TRAVIS_PULL_REQUEST\} \|\| ''
 ;authordep warnings                    = 1.03
 
 [Prereqs / TestRequires]
-Test::CleanNamespaces = 0.13
 Test::Fatal           = 0.001
 Test::More            = 0.96
 Test::Needs           = 0.002010

--- a/t/metaclasses/exporter_sub_names.t
+++ b/t/metaclasses/exporter_sub_names.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 
-use Test::CleanNamespaces;
 use Test::More;
 
 {
@@ -9,16 +8,10 @@ use Test::More;
     use Moose::Role;
 }
 
-$::HAS_NC_AC = 0;
-
 {
     package Foo;
     use Moose ();
     use Moose::Exporter;
-    {
-        local $@;
-        eval 'use namespace::autoclean; $::HAS_NC_AC = 1';
-    }
 
     Moose::Exporter->setup_import_methods(
         also            => 'Moose',
@@ -33,12 +26,7 @@ $::HAS_NC_AC = 0;
         ::is( $package, __PACKAGE__, "$name sub is in Foo package" );
         ::is( $sub_name, $name, "$name sub has that name, not __ANON__" );
     }
-}
 
-if ($::HAS_NC_AC) {
-    $INC{'Foo.pm'} = 1;
-    namespaces_clean('Foo');
 }
 
 done_testing();
-


### PR DESCRIPTION
The test was using namespace::autoclean to clean a namespace, then checking that it was cleaned via Test::CleanNamespaces. This essentially ends up only being a test of the external modules, not anything about Moose itself. Both modules are using Moose to get the list of methods. If that method list was wrong, the test would still pass because the same list is being provided to both modules. And Moose's tests don't need to include tests that are only of external modules.