### PR TITLE
Fix term "array" into "list" 2x in POD for Moose::Meta::Class

### DIFF
--- a/lib/Moose/Meta/Class.pm
+++ b/lib/Moose/Meta/Class.pm
@@ -892,12 +892,12 @@ This adds an C<augment> method modifier to the package.
 
 =item B<< $metaclass->calculate_all_roles >>
 
-This will return a unique array of L<Moose::Meta::Role> instances
+This will return a unique list of L<Moose::Meta::Role> instances
 which are attached to this class.
 
 =item B<< $metaclass->calculate_all_roles_with_inheritance >>
 
-This will return a unique array of L<Moose::Meta::Role> instances
+This will return a unique list of L<Moose::Meta::Role> instances
 which are attached to this class, and each of this class's ancestors.
 
 =item B<< $metaclass->add_role($role) >>


### PR DESCRIPTION
I recently fiddled with some Moose meta objects to inspect objects and realized that this method was documented incorrectly. The code doesn't return an arrayref but a _list_ of values.