### PR TITLE
"attribute required" documentation improvements

### DIFF
--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -1433,8 +1433,8 @@ An attribute which is required must be provided to the constructor. An
 attribute which is required can also have a C<default> or C<builder>,
 which will satisfy its required-ness.
 
-A required attribute must have a C<default>, C<builder> or a
-non-C<undef> C<init_arg>
+If C<init_arg> is C<undef> on a required attribute, it must have a
+C<default> or a C<builder>.
 
 =item * lazy => $bool
 

--- a/lib/Moose/Meta/Attribute.pm
+++ b/lib/Moose/Meta/Attribute.pm
@@ -1359,7 +1359,10 @@ by that parent class.
 
 =head1 INHERITANCE
 
-C<Moose::Meta::Attribute> is a subclass of L<Class::MOP::Attribute>.
+C<Moose::Meta::Attribute> is a subclass of L<Class::MOP::Attribute> and
+inherits these options:
+C<init_arg> C<builder> C<default> C<initializer> C<accessor> C<reader>
+C<writer> C<predicate> C<clearer> C<definition_context>
 
 =head1 METHODS
 


### PR DESCRIPTION
In trying to figure out some of the specifics of "required" i ended up struggling a bit with the documentations, and after talking with @haarg about it on IRC ended up with two suggestions for improvements.

First off the sentence about default+builder+init_arg was not structured in an obvious way as to what the intent of it was. The rewriting explains the intent first and then how to address the issue.

Additionally the sentence also mentions init_arg which is inherited from Class::MOP::Attribute and otherwise not mentioned in the document at all, making it a bit of a big question mark. Manually mentioning the important inherited options would help that. @haarg also suggested that this could be applied broadly to the moose docs.