### PR TITLE
t/basics/definition_context.t - adapt for improved line number reporting

### DIFF
--- a/t/basics/definition_context.t
+++ b/t/basics/definition_context.t
@@ -9,6 +9,16 @@ use Class::MOP::Class;
 use Moose::Meta::Class;
 use Moose::Meta::Attribute;
 
+# Detect the line number reporting behaviour of this version of perl
+our $use_block_end;
+BEGIN {
+    sub X { my (undef, undef, $line) = caller;
+                $use_block_end++ if ($line != shift); }
+    X __LINE__, # $use_block_end = 0
+    sub { }     # $use_block_end = 1
+};
+
+
 my %tests = (
     'Class::MOP::Class superclasses attribute' => {
         attribute => Class::MOP::Class->meta->find_attribute_by_name('superclasses'),
@@ -17,7 +27,7 @@ my %tests = (
 
         # This is obviously pretty fragile, so let's not test the line for
         # more than one attribute.
-        line => 308,
+        line => ($use_block_end ? 308 : 298),
     },
     'Moose::Meta::Class roles attribute' => {
         attribute => Moose::Meta::Class->meta->find_attribute_by_name('roles'),


### PR DESCRIPTION
Early in the next development cycle of the perl interpreter, an attempt will be made to improve the inaccuracy of line number reporting by warnings/error and caller(), starting with:

* https://github.com/Perl/perl5/pull/24387 - starting statement in elsif() blocks
* https://github.com/Perl/perl5/pull/24389 - loop condition statements
* https://github.com/Perl/perl5/pull/24396 - mid-statement anon sub declarations

These changes break one test in this module written to match a specific emitted line number.

This commit should ensure that the affected test succeeds regardless of whether the perl version in use demonstrates the older, buggier behaviour or the behaviour once the above pull requests are merged. (This would also reduce churn if those PRs are merged and present in some tagged releases, but then later reverted.)